### PR TITLE
Use mirrored http_archive for hermetic builds

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -11,3 +11,4 @@
 
 Damien Martin-Guillerez <dmarting@google.com>
 David Chen <dzc@google.com>
+Justine Alexandra Roberts Tunney <jart@google.com>

--- a/README.md
+++ b/README.md
@@ -21,10 +21,11 @@ To use the Jsonnet rules, add the following to your `WORKSPACE` file to add the
 external repositories for Jsonnet:
 
 ```python
-git_repository(
+http_archive(
     name = "io_bazel_rules_jsonnet",
-    remote = "https://github.com/bazelbuild/rules_jsonnet.git",
-    tag = "0.0.1",
+    url = "https://github.com/bazelbuild/rules_jsonnet/archive/0.0.2.tar.gz",
+    sha256 = "5f788c7719a02ed2483641365f194e9e5340fbe54963d6d6caa09f91454d38b8",
+    stirp_prefix = "rules_jsonnet-0.0.2",
 )
 load("@io_bazel_rules_jsonnet//jsonnet:jsonnet.bzl", "jsonnet_repositories")
 

--- a/jsonnet/jsonnet.bzl
+++ b/jsonnet/jsonnet.bzl
@@ -243,8 +243,9 @@ jsonnet_to_json_test = rule(
 )
 
 def jsonnet_repositories():
-  native.git_repository(
+  native.http_archive(
       name = "jsonnet",
-      remote = "https://github.com/google/jsonnet.git",
-      tag = "v0.8.8",
+      url = "http://bazel-mirror.storage.googleapis.com/github.com/google/jsonnet/archive/v0.8.8.tar.gz",
+      sha256 = "668f4ffe1796d22902a485e0c383c1e149dcf7b5364c1bd79e48d8a62b4943b9",
+      strip_prefix = "jsonnet-0.8.8",
   )


### PR DESCRIPTION
`git_repository` isn't fully hermetic since it doesn't have the checksum. We've encountered problems with it in certain situations: https://github.com/bazelbuild/bazel/issues/1515 It also wastes cpu/disk, since the tarball is much smaller than the whole git repo. Therefore `http_archive` is preferable.

I've also mirrored your files for guaranteed reliability, courtesy of Google Cloud Storage.

In the future, you can mirror these files too with the following command. Although you need to ask @damienmg for write access to the bucket. Or just email me the URL you want mirrored and I'll happily do it.

```bash
bzmirror() {
  local url="${1:?url}"
  if [[ "${url}" =~ ^([^:]+):([^:]+):([^:]+)$ ]]; then
    url="http://repo1.maven.org/maven2/${BASH_REMATCH[1]//.//}/${BASH_REMATCH[2]}/${BASH_REMATCH[3]}/${BASH_REMATCH[2]}-${BASH_REMATCH[3]}.jar"
  fi
  local dest="gs://bazel-mirror/${url#http*//}"
  local desturl="http://bazel-mirror.storage.googleapis.com/${url#http*//}"
  local name="$(basename "${dest}")"
  wget -O "/tmp/${name}" "${url}" || return 1
  gsutil cp -a public-read "/tmp/${name}" "${dest}" || return 1
  gsutil setmeta -h 'Cache-Control:public, max-age=31536000' "${dest}" || return 1
  curl -I "${desturl}"
  echo
  sha256sum "/tmp/${name}"
  echo "${desturl}"
  rm "/tmp/${name}" || return 1
}
```