### PR TITLE
update jsonnet version to 0.9.4 from 0.8.8

### DIFF
--- a/jsonnet/jsonnet.bzl
+++ b/jsonnet/jsonnet.bzl
@@ -613,9 +613,8 @@ def jsonnet_repositories():
   native.http_archive(
       name = "jsonnet",
       urls = [
-          "http://mirror.bazel.build/github.com/google/jsonnet/archive/v0.8.8.tar.gz",
-          "https://github.com/google/jsonnet/archive/v0.8.8.tar.gz",
+          "https://github.com/google/jsonnet/archive/v0.9.4.tar.gz",
       ],
-      sha256 = "668f4ffe1796d22902a485e0c383c1e149dcf7b5364c1bd79e48d8a62b4943b9",
-      strip_prefix = "jsonnet-0.8.8",
+      sha256 = "7fe24208ff97cb563fee4f6a67a4dd831622841d345b2549b47e1243295f5ec3",
+      strip_prefix = "jsonnet-0.9.4",
   )


### PR DESCRIPTION
The current jsonnet version in these rules is more than a year out of date. It was failing to import Ksonnet for me. This updates to the latest release.

N.B., you may want to cache and include the cache url in the http_archive cmd, I removed it because I don't know how that works with y'alls system. 

Also, if there are any tools that aid in updating external dependencies in bazel, please let me know. This is an obvious pain point for me. 