### PR TITLE
upgrade jsonnet to v0.9.5

### DIFF
--- a/jsonnet/jsonnet.bzl
+++ b/jsonnet/jsonnet.bzl
@@ -613,9 +613,9 @@ def jsonnet_repositories():
   native.http_archive(
       name = "jsonnet",
       urls = [
-          "http://mirror.bazel.build/github.com/google/jsonnet/archive/v0.8.8.tar.gz",
-          "https://github.com/google/jsonnet/archive/v0.8.8.tar.gz",
+          "http://mirror.bazel.build/github.com/google/jsonnet/archive/v0.9.5.tar.gz",
+          "https://github.com/google/jsonnet/archive/v0.9.5.tar.gz",
       ],
-      sha256 = "668f4ffe1796d22902a485e0c383c1e149dcf7b5364c1bd79e48d8a62b4943b9",
-      strip_prefix = "jsonnet-0.8.8",
+      sha256 = "f504b6079882a18f0e8304f9e230f04eff70c2f0fb94a18fc26cbf989c7d838b",
+      strip_prefix = "jsonnet-0.9.5",
   )

--- a/jsonnet/jsonnet.bzl
+++ b/jsonnet/jsonnet.bzl
@@ -613,7 +613,7 @@ def jsonnet_repositories():
   native.http_archive(
       name = "jsonnet",
       urls = [
-          "http://mirror.bazel.build/github.com/google/jsonnet/archive/v0.9.5.tar.gz",
+          "https://mirror.bazel.build/github.com/google/jsonnet/archive/v0.9.5.tar.gz",
           "https://github.com/google/jsonnet/archive/v0.9.5.tar.gz",
       ],
       sha256 = "f504b6079882a18f0e8304f9e230f04eff70c2f0fb94a18fc26cbf989c7d838b",


### PR DESCRIPTION
fixes #15 

TODO:
- [ ] someone needs to upload the v0.9.5 tarball to the bazel mirror