### PR TITLE
allow .json file to be specified as source

### DIFF
--- a/jsonnet/jsonnet.bzl
+++ b/jsonnet/jsonnet.bzl
@@ -39,7 +39,7 @@ jsonnet_repositories()
 ```
 """
 
-_JSONNET_FILETYPE = FileType([".jsonnet", ".libsonnet"])
+_JSONNET_FILETYPE = FileType([".jsonnet", ".libsonnet", ".json"])
 
 def _setup_deps(deps):
   """Collects source files and import flags of transitive dependencies.


### PR DESCRIPTION
jsonnet is a super set of json, so json files should be considered valid jsonnet sources too.