### PR TITLE
Add support for external files and env vars.

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,61 +232,80 @@ local foo = import "foo.jsonnet";
       </td>
     </tr>
     <tr>
-      <td><code>vars</code></td>
+      <td><code>ext_strs</code></td>
       <td>
         <code>String dict, optional</code>
         <p>
-          Map of variables to pass to jsonnet via <code>--var key=value</code>.
+          Map of strings to pass to jsonnet as external variables via <code>--ext-str key=value</code>.
         </p>
       </td>
     </tr>
     <tr>
-      <td><code>code_vars</code></td>
+      <td><code>ext_str_envs</code></td>
       <td>
-        <code>String dict, optional</code>
+        <code>String list, optional</code>
         <p>
-          Map of code variables to pass to jsonnet via
-          <code>--code-var key=value</code>.
+          List of env var names containing strings to pass to jsonnet as external variables via <code>--ext-str key</code>.
         </p>
       </td>
     </tr>
-        <tr>
-      <td><code>files</code></td>
+    <tr>
+      <td><code>ext_code</code></td>
+      <td>
+        <code>String dict, optional</code>
+        <p>
+          Map of code to pass to jsonnet as external variables via
+          <code>--ext-code key=value</code>.
+        </p>
+      </td>
+    </tr>
+    <tr>
+      <td><code>ext_code_envs</code></td>
+      <td>
+        <code>String list, optional</code>
+        <p>
+          List of env var names containing jsonnet code to pass to jsonnet as external variables via
+          <code>--ext-code key</code>.
+        </p>
+      </td>
+    </tr>
+    <tr>
+      <td><code>ext_str_files</code></td>
       <td>
         <code>List of labels, optional but needed together with file_vars</code>
         <p>
-          List of files that map to the var name defined in file_vars at the same index and together are passed to jsonnet via
-          <code>--file var=file</code>.
+          List of string files that map to the var name defined in file_vars at the same index and together are passed to jsonnet via
+          <code>--ext-str-file var=file</code>.
         </p>
       </td>
     </tr>
     <tr>
-      <td><code>file_vars</code></td>
+      <td><code>ext_str_file_vars</code></td>
       <td>
         <code>List of string, optional but needed together with files</code>
         <p>
           List of var names that maps to the file defined in files at the same index and together are passed to jsonnet via
-          <code>--file var=file</code>.
+          <code>--ext-str-file var=file</code>.
         </p>
       </td>
     </tr>
     <tr>
-      <td><code>code_files</code></td>
+      <td><code>ext_code_files</code></td>
       <td>
         <code>String dict, optional</code>
         <p>
-          List of jsonnet code files that map to the var name defined in code_file_vars at the same index and together are passed to jsonnet via
-          <code>--code-file var=file</code>.
+          List of jsonnet code files that map to the var name defined in ext_code_file_vars at the same index and together are passed to jsonnet via
+          <code>--ext-code-file var=file</code>.
         </p>
       </td>
     </tr>
     <tr>
-      <td><code>code_file_vars</code></td>
+      <td><code>ext_code_file_vars</code></td>
       <td>
         <code>String dict, optional</code>
         <p>
           List of var names that maps to the code file defined in code_files at the same index and together are passed to jsonnet via
-          <code>--code-file var=file</code>.
+          <code>--ext-code-file var=file</code>.
         </p>
       </td>
     </tr>
@@ -454,61 +473,80 @@ jsonnet_to_json_test(name, src, deps, imports, golden, error=0, regex=False)
       </td>
     </tr>
     <tr>
-      <td><code>vars</code></td>
+      <td><code>ext_strs</code></td>
       <td>
         <code>String dict, optional</code>
         <p>
-          Map of variables to pass to jsonnet via <code>--var key=value</code>.
+          Map of strings to pass to jsonnet as external variables via <code>--ext-str key=value</code>.
         </p>
       </td>
     </tr>
     <tr>
-      <td><code>code_vars</code></td>
+      <td><code>ext_str_envs</code></td>
       <td>
-        <code>String dict, optional</code>
+        <code>String list, optional</code>
         <p>
-          Map of code variables to pass to jsonnet via
-          <code>--code-var key=value</code>.
+          List of env var names containing strings to pass to jsonnet as external variables via <code>--ext-str key</code>.
         </p>
       </td>
     </tr>
-        <tr>
-      <td><code>files</code></td>
+    <tr>
+      <td><code>ext_code</code></td>
+      <td>
+        <code>String dict, optional</code>
+        <p>
+          Map of code to pass to jsonnet as external variables via
+          <code>--ext-code key=value</code>.
+        </p>
+      </td>
+    </tr>
+    <tr>
+      <td><code>ext_code_envs</code></td>
+      <td>
+        <code>String list, optional</code>
+        <p>
+          List of env var names containing jsonnet code to pass to jsonnet as external variables via
+          <code>--ext-code key</code>.
+        </p>
+      </td>
+    </tr>
+    <tr>
+      <td><code>ext_str_files</code></td>
       <td>
         <code>List of labels, optional but needed together with file_vars</code>
         <p>
-          List of files that map to the var name defined in file_vars at the same index and together are passed to jsonnet via
-          <code>--file var=file</code>.
+          List of string files that map to the var name defined in file_vars at the same index and together are passed to jsonnet via
+          <code>--ext-str-file var=file</code>.
         </p>
       </td>
     </tr>
     <tr>
-      <td><code>file_vars</code></td>
+      <td><code>ext_str_file_vars</code></td>
       <td>
         <code>List of string, optional but needed together with files</code>
         <p>
           List of var names that maps to the file defined in files at the same index and together are passed to jsonnet via
-          <code>--file var=file</code>.
+          <code>--ext-str-file var=file</code>.
         </p>
       </td>
     </tr>
     <tr>
-      <td><code>code_files</code></td>
+      <td><code>ext_code_files</code></td>
       <td>
         <code>String dict, optional</code>
         <p>
-          List of jsonnet code files that map to the var name defined in code_file_vars at the same index and together are passed to jsonnet via
-          <code>--code-file var=file</code>.
+          List of jsonnet code files that map to the var name defined in ext_code_file_vars at the same index and together are passed to jsonnet via
+          <code>--ext-code-file var=file</code>.
         </p>
       </td>
     </tr>
     <tr>
-      <td><code>code_file_vars</code></td>
+      <td><code>ext_code_file_vars</code></td>
       <td>
         <code>String dict, optional</code>
         <p>
           List of var names that maps to the code file defined in code_files at the same index and together are passed to jsonnet via
-          <code>--code-file var=file</code>.
+          <code>--ext-code-file var=file</code>.
         </p>
       </td>
     </tr>

--- a/README.md
+++ b/README.md
@@ -250,6 +250,46 @@ local foo = import "foo.jsonnet";
         </p>
       </td>
     </tr>
+        <tr>
+      <td><code>files</code></td>
+      <td>
+        <code>List of labels, optional but needed together with file_vars</code>
+        <p>
+          List of files that map to the var name defined in file_vars at the same index and together are passed to jsonnet via
+          <code>--file var=file</code>.
+        </p>
+      </td>
+    </tr>
+    <tr>
+      <td><code>file_vars</code></td>
+      <td>
+        <code>List of string, optional but needed together with files</code>
+        <p>
+          List of var names that maps to the file defined in files at the same index and together are passed to jsonnet via
+          <code>--file var=file</code>.
+        </p>
+      </td>
+    </tr>
+    <tr>
+      <td><code>code_files</code></td>
+      <td>
+        <code>String dict, optional</code>
+        <p>
+          List of jsonnet code files that map to the var name defined in code_file_vars at the same index and together are passed to jsonnet via
+          <code>--code-file var=file</code>.
+        </p>
+      </td>
+    </tr>
+    <tr>
+      <td><code>code_file_vars</code></td>
+      <td>
+        <code>String dict, optional</code>
+        <p>
+          List of var names that maps to the code file defined in code_files at the same index and together are passed to jsonnet via
+          <code>--code-file var=file</code>.
+        </p>
+      </td>
+    </tr>
   </tbody>
 </table>
 
@@ -406,7 +446,7 @@ jsonnet_to_json_test(name, src, deps, imports, golden, error=0, regex=False)
     <tr>
       <td><code>imports</code></td>
       <td>
-        <code>List of strings, optional</code>
+        <code>codefileList of strings, optional</code>
         <p>
           List of import <code>-J</code> flags to be passed to the
           <code>jsonnet</code> compiler.
@@ -429,6 +469,46 @@ jsonnet_to_json_test(name, src, deps, imports, golden, error=0, regex=False)
         <p>
           Map of code variables to pass to jsonnet via
           <code>--code-var key=value</code>.
+        </p>
+      </td>
+    </tr>
+        <tr>
+      <td><code>files</code></td>
+      <td>
+        <code>List of labels, optional but needed together with file_vars</code>
+        <p>
+          List of files that map to the var name defined in file_vars at the same index and together are passed to jsonnet via
+          <code>--file var=file</code>.
+        </p>
+      </td>
+    </tr>
+    <tr>
+      <td><code>file_vars</code></td>
+      <td>
+        <code>List of string, optional but needed together with files</code>
+        <p>
+          List of var names that maps to the file defined in files at the same index and together are passed to jsonnet via
+          <code>--file var=file</code>.
+        </p>
+      </td>
+    </tr>
+    <tr>
+      <td><code>code_files</code></td>
+      <td>
+        <code>String dict, optional</code>
+        <p>
+          List of jsonnet code files that map to the var name defined in code_file_vars at the same index and together are passed to jsonnet via
+          <code>--code-file var=file</code>.
+        </p>
+      </td>
+    </tr>
+    <tr>
+      <td><code>code_file_vars</code></td>
+      <td>
+        <code>String dict, optional</code>
+        <p>
+          List of var names that maps to the code file defined in code_files at the same index and together are passed to jsonnet via
+          <code>--code-file var=file</code>.
         </p>
       </td>
     </tr>

--- a/examples/BUILD
+++ b/examples/BUILD
@@ -71,3 +71,24 @@ jsonnet_to_json_test(
     src = "invalid.jsonnet",
     error = 1,
 )
+
+jsonnet_to_json(
+    name = "files",
+    src = "files.jsonnet",
+    outs = ["files.json"],
+    files = [":file.txt"],
+    file_vars = ["test"],
+    code_files = [":codefile.libsonnet"],
+    code_file_vars = ["codefile"],
+)
+
+jsonnet_to_json_test(
+    name = "files_test",
+    size = "small",
+    src = "files.jsonnet",
+    files = [":file.txt"],
+    file_vars = ["test"],
+    code_files = [":codefile.libsonnet"],
+    code_file_vars = ["codefile"],
+    golden = "files.out",
+)

--- a/examples/BUILD
+++ b/examples/BUILD
@@ -76,20 +76,24 @@ jsonnet_to_json(
     name = "files",
     src = "files.jsonnet",
     outs = ["files.json"],
-    files = [":file.txt"],
-    file_vars = ["test"],
-    code_files = [":codefile.libsonnet"],
-    code_file_vars = ["codefile"],
+    ext_str_envs = ["MYTEST"],
+    ext_code_envs = ["MYJSONNET"],
+    ext_str_files = [":file.txt"],
+    ext_str_file_vars = ["test"],
+    ext_code_files = [":codefile.libsonnet"],
+    ext_code_file_vars = ["codefile"],
 )
 
 jsonnet_to_json_test(
     name = "files_test",
     size = "small",
     src = "files.jsonnet",
-    files = [":file.txt"],
-    file_vars = ["test"],
-    code_files = [":codefile.libsonnet"],
-    code_file_vars = ["codefile"],
+    ext_str_envs = ["MYTEST"],
+    ext_code_envs = ["MYJSONNET"],
+    ext_str_files = [":file.txt"],
+    ext_str_file_vars = ["test"],
+    ext_code_files = [":codefile.libsonnet"],
+    ext_code_file_vars = ["codefile"],
     golden = "files.out",
 )
 

--- a/examples/codefile.libsonnet
+++ b/examples/codefile.libsonnet
@@ -1,0 +1,3 @@
+{
+  weather: "Finally spring!"
+}

--- a/examples/file.txt
+++ b/examples/file.txt
@@ -1,0 +1,1 @@
+this is great

--- a/examples/files.jsonnet
+++ b/examples/files.jsonnet
@@ -1,0 +1,7 @@
+local test = std.extVar("test");
+local codefile = std.extVar("codefile");
+
+{
+  file1: test,
+  file2: codefile.weather,
+}

--- a/examples/files.jsonnet
+++ b/examples/files.jsonnet
@@ -1,7 +1,11 @@
 local test = std.extVar("test");
 local codefile = std.extVar("codefile");
+local my_test = std.extVar("MYTEST");
+local my_jsonnet = std.extVar("MYJSONNET");
 
 {
   file1: test,
   file2: codefile.weather,
+  my_test: my_test,
+  my_jsonnet: my_jsonnet.code,
 }

--- a/examples/files.out
+++ b/examples/files.out
@@ -1,4 +1,6 @@
 {
   "file1": "this is great\n",
-  "file2": "Finally spring!"
+  "file2": "Finally spring!",
+  "my_test": "test",
+  "my_jsonnet": "some code",
 }

--- a/examples/files.out
+++ b/examples/files.out
@@ -1,0 +1,4 @@
+{
+  "file1": "this is great\n",
+  "file2": "Finally spring!"
+}

--- a/jsonnet/jsonnet.bzl
+++ b/jsonnet/jsonnet.bzl
@@ -106,9 +106,9 @@ def _jsonnet_to_json_impl(ctx):
       ["--var '%s'='%s'"
        % (var, ctx.expand_make_variables("vars", jsonnet_vars[var],{})) for var in jsonnet_vars.keys()] +
       ["--code-var '%s'='%s'"
-       % (var, jsonnet_code_vars[var]) for var in jsonnet_code_vars.keys()])
+       % (var, jsonnet_code_vars[var]) for var in jsonnet_code_vars.keys()] +
       ["--file '%s'='%s'"
-       % (var, jsonnet_files[var]) for var in jsonnet_files.keys()])
+       % (var, jsonnet_files[var]) for var in jsonnet_files.keys()] +
       ["--code-file '%s'='%s'"
        % (var, jsonnet_code_files[var]) for var in jsonnet_code_files.keys()])
 

--- a/jsonnet/jsonnet.bzl
+++ b/jsonnet/jsonnet.bzl
@@ -107,17 +107,17 @@ def _jsonnet_to_json_impl(ctx):
       ["-J .",
        "-J %s" % ctx.genfiles_dir.path,
        "-J %s" % ctx.bin_dir.path] +
-      ["--var '%s'='%s'"
+      ["--ext-str '%s'='%s'"
        % (var, ctx.expand_make_variables("vars", jsonnet_ext_strs[var],{})) for var in jsonnet_ext_strs.keys()] +
-      ["--var '%s'"
+      ["--ext-str '%s'"
        % ext_str_env for ext_str_env in jsonnet_ext_str_envs] +
-      ["--code-var '%s'='%s'"
+      ["--ext-code '%s'='%s'"
        % (var, jsonnet_ext_code[var]) for var in jsonnet_ext_code.keys()] +
-      ["--code-var '%s'"
+      ["--ext-code '%s'"
        % ext_code_env for ext_code_env in jsonnet_ext_code_envs] +
-      ["--file %s=%s"
+      ["--ext-str-file %s=%s"
        % (var, list(jfile.files)[0].path) for var, jfile in zip(jsonnet_ext_str_file_vars, jsonnet_ext_str_files)] +
-      ["--code-file %s=%s"
+      ["--ext-code-file %s=%s"
        % (var, list(jfile.files)[0].path) for var, jfile in zip(jsonnet_ext_code_file_vars, jsonnet_ext_code_files)])
 
   outputs = []
@@ -236,17 +236,17 @@ def _jsonnet_to_json_test_impl(ctx):
       ["-J %s/%s" % (ctx.label.package, im) for im in ctx.attr.imports] +
       ["-J %s" % im for im in depinfo.imports] +
       ["-J ."] +
-      ["--var %s=%s"
+      ["--ext-str %s=%s"
        % (var, ctx.expand_make_variables("vars", jsonnet_ext_strs[var],{})) for var in jsonnet_ext_strs.keys()] +
-      ["--var %s"
+      ["--ext-str %s"
        % ext_str_env for ext_str_env in jsonnet_ext_str_envs] +
-      ["--code-var %s=%s"
+      ["--ext-code %s=%s"
        % (var, jsonnet_ext_code[var]) for var in jsonnet_ext_code.keys()] +
-      ["--code-var %s"
+      ["--ext-code %s"
        % ext_code_env for ext_code_env in jsonnet_ext_code_envs] +
-      ["--file %s=%s"
+      ["--ext-str-file %s=%s"
        % (var, list(jfile.files)[0].path) for var, jfile in zip(jsonnet_ext_str_file_vars, jsonnet_ext_str_files)] +
-      ["--code-file %s=%s"
+      ["--ext-code-file %s=%s"
        % (var, list(jfile.files)[0].path) for var, jfile in zip(jsonnet_ext_code_file_vars, jsonnet_ext_code_files)] +
       [
           ctx.file.src.short_path,

--- a/jsonnet/jsonnet.bzl
+++ b/jsonnet/jsonnet.bzl
@@ -91,6 +91,8 @@ def _jsonnet_to_json_impl(ctx):
   toolchain = _jsonnet_toolchain(ctx)
   jsonnet_vars = ctx.attr.vars
   jsonnet_code_vars = ctx.attr.code_vars
+  jsonnet_files = ctx.attr.files
+  jsonnet_code_files = ctx.attr.code_files
   command = (
       [
           "set -e;",
@@ -105,6 +107,10 @@ def _jsonnet_to_json_impl(ctx):
        % (var, ctx.expand_make_variables("vars", jsonnet_vars[var],{})) for var in jsonnet_vars.keys()] +
       ["--code-var '%s'='%s'"
        % (var, jsonnet_code_vars[var]) for var in jsonnet_code_vars.keys()])
+      ["--file '%s'='%s'"
+       % (var, jsonnet_files[var]) for var in jsonnet_files.keys()])
+      ["--code-file '%s'='%s'"
+       % (var, jsonnet_code_files[var]) for var in jsonnet_code_files.keys()])
 
   outputs = []
   # If multiple_outputs is set to true, then jsonnet will be invoked with the
@@ -320,6 +326,8 @@ _jsonnet_compile_attrs = {
     ),
     "vars": attr.string_dict(),
     "code_vars": attr.string_dict(),
+    "files": attr.string_dict(),
+    "code_files": attr.string_dict(),
 }
 
 _jsonnet_to_json_attrs = {

--- a/tools/bazel.rc
+++ b/tools/bazel.rc
@@ -1,0 +1,2 @@
+build @io_bazel_rules_jsonnet//examples:files_test --action_env MYTEST="test" --action_env MYJSONNET="{code: 'some code'}"
+build @io_bazel_rules_jsonnet//examples:files --action_env MYTEST="test" --action_env MYJSONNET="{code: 'some code'}"

--- a/tools/bazel.rc
+++ b/tools/bazel.rc
@@ -1,2 +1,1 @@
-build @io_bazel_rules_jsonnet//examples:files_test --action_env MYTEST="test" --action_env MYJSONNET="{code: 'some code'}"
-build @io_bazel_rules_jsonnet//examples:files --action_env MYTEST="test" --action_env MYJSONNET="{code: 'some code'}"
+build --action_env MYTEST="test" --action_env MYJSONNET="{code: 'some code'}"


### PR DESCRIPTION
We have a use-case for these flags so added support. Unfortunately bazel does not seem to expose a `string_keyed_label_dict` (see: https://github.com/bazelbuild/bazel/issues/1232) so only managed to implement it with two lists that are getting zipped up. Also added a test and docs.

If there is a better way to implement, happy to do so.