### PR TITLE
Append package names to genfiles_dir and bin_dir paths

### DIFF
--- a/jsonnet/jsonnet.bzl
+++ b/jsonnet/jsonnet.bzl
@@ -113,9 +113,11 @@ def _jsonnet_to_json_impl(ctx):
       ["-J %s/%s" % (ctx.label.package, im) for im in ctx.attr.imports] +
       ["-J %s" % im for im in depinfo.imports] +
       ["-J .",
+       "-J %s/%s" % (ctx.genfiles_dir.path, ctx.label.package),
        "-J %s" % ctx.genfiles_dir.path,
+       "-J %s/%s" % (ctx.bin_dir.path, ctx.label.package),
        "-J %s" % ctx.bin_dir.path] +
-      yaml_stream_arg +
+       yaml_stream_arg +
       ["--ext-str %s=%s"
        % (_quote(key), _quote(ctx.var[val])) for key, val in jsonnet_ext_strs.items()] +
       ["--ext-str '%s'"


### PR DESCRIPTION
Libraries created by genrules can't be found because Bazel creates a directory structure that matches the package names that were used to generate those libraries. Those package names could be the current package, or other packages. 

As a result, it is not sufficient to include `-J ctx.genfiles_dir.path`.

This may result in duplicate directories following -J. If this is a concern, it may be possible to deduplicate the list.