### PR TITLE
Remove usages of deprecated Bazel features

### DIFF
--- a/jsonnet/jsonnet.bzl
+++ b/jsonnet/jsonnet.bzl
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
 """Jsonnet Rules
 
 These are build rules for working with [Jsonnet][jsonnet] files with Bazel.
@@ -675,7 +677,7 @@ Example:
 
 def jsonnet_repositories():
   """Adds the external dependencies needed for the Jsonnet rules."""
-  native.http_archive(
+  http_archive(
       name = "jsonnet",
       urls = [
           "https://mirror.bazel.build/github.com/google/jsonnet/archive/v0.10.0.tar.gz",

--- a/jsonnet/jsonnet.bzl
+++ b/jsonnet/jsonnet.bzl
@@ -119,7 +119,7 @@ def _jsonnet_to_json_impl(ctx):
           toolchain.jsonnet_path,
       ] +
       ["-J %s/%s" % (ctx.label.package, im) for im in ctx.attr.imports] +
-      ["-J %s" % im for im in depinfo.imports] +
+      ["-J %s" % im for im in depinfo.imports.to_list()] +
       ["-J .",
        "-J %s" % ctx.genfiles_dir.path,
        "-J %s" % ctx.bin_dir.path] +
@@ -169,8 +169,8 @@ def _jsonnet_to_json_impl(ctx):
 
   compile_inputs = (
       [ctx.file.src, ctx.executable.jsonnet] +
-      list(runfiles.files) +
-      list(depinfo.transitive_sources))
+      runfiles.files.to_list() +
+      depinfo.transitive_sources.to_list())
 
   ctx.action(
       inputs = compile_inputs,

--- a/jsonnet/jsonnet.bzl
+++ b/jsonnet/jsonnet.bzl
@@ -311,7 +311,7 @@ _jsonnet_common_attrs = {
         default = Label("@jsonnet//cmd:jsonnet"),
         cfg = "host",
         executable = True,
-        single_file = True,
+        allow_single_file = True,
     ),
     "data": attr.label_list(
         allow_files = True,
@@ -367,10 +367,7 @@ Example:
 """
 
 _jsonnet_compile_attrs = {
-    "src": attr.label(
-        allow_files = _JSONNET_FILETYPE,
-        single_file = True,
-    ),
+    "src": attr.label(allow_single_file = _JSONNET_FILETYPE),
     "ext_strs": attr.string_dict(),
     "ext_str_envs": attr.string_list(),
     "ext_code": attr.string_dict(),
@@ -544,10 +541,7 @@ Example:
 """
 
 _jsonnet_to_json_test_attrs = {
-    "golden": attr.label(
-        allow_files = True,
-        single_file = True,
-    ),
+    "golden": attr.label(allow_single_file = True),
     "error": attr.int(),
     "regex": attr.bool(),
     "yaml_stream": attr.bool(default = False, mandatory = False),

--- a/jsonnet/jsonnet.bzl
+++ b/jsonnet/jsonnet.bzl
@@ -168,12 +168,15 @@ def _jsonnet_to_json_impl(ctx):
   )
 
   compile_inputs = (
-      [ctx.file.src, ctx.executable.jsonnet] +
+      [ctx.file.src] +
       runfiles.files.to_list() +
       depinfo.transitive_sources.to_list())
 
-  ctx.action(
+  tools = [ctx.executable.jsonnet]
+
+  ctx.actions.run_shell(
       inputs = compile_inputs,
+      tools = tools,
       outputs = outputs,
       mnemonic = "Jsonnet",
       command = " ".join(command),


### PR DESCRIPTION
This makes rules_jsonnet compatible with `--all_incompatible_changes`, best I can tell.