### PR TITLE
Fix broken README.md formatting.

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,7 +261,7 @@ VAR1 value1
 # This can be overriden by users if they "export CLUSTER_OVERRIDE"
 CLUSTER ${CLUSTER_OVERRIDE:-default-value2}
 EOF
-
+</pre>
       </td>
     </tr>
     <tr>


### PR DESCRIPTION
The recent stamping merge left out a closing `</pre>` tag in the readme file.