### PR TITLE
Remove "data" from  _jsonnet_common_attrs

### DIFF
--- a/jsonnet/jsonnet.bzl
+++ b/jsonnet/jsonnet.bzl
@@ -376,9 +376,6 @@ _jsonnet_common_attrs = {
         executable = True,
         allow_single_file = True,
     ),
-    "data": attr.label_list(
-        allow_files = True,
-    ),
 }
 
 _jsonnet_library_attrs = {


### PR DESCRIPTION
This property does not seem to be used. However, on bazel 0.14 or 0.15, it causes the following error with _any_ jsonnet_library rule.

```BUILD:3:1: jsonnet_library attribute data is not configured for the data configuration```