### PR TITLE
test: Feed diff multiline input for better line-level difference resolution

### DIFF
--- a/jsonnet/jsonnet.bzl
+++ b/jsonnet/jsonnet.bzl
@@ -253,7 +253,7 @@ GOLDEN=$(%s %s)
 if [ "$OUTPUT" != "$GOLDEN" ]; then
   echo "FAIL (output mismatch): %s"
   echo "Diff:"
-  diff <(echo $GOLDEN) <(echo $OUTPUT)
+  diff <(echo "$GOLDEN") <(echo "$OUTPUT")
   echo "Expected: $GOLDEN"
   echo "Actual: $OUTPUT"
   exit 1


### PR DESCRIPTION
When the `jsonnet_to_json_test` rule's action runs to compare Jsonnet's evaluation output to a canonical golden file, it collects these two output sources into shell variables, then feeds them to the
_diff_ command via input redirection with _echo_. However, by supplying _echo_ with unquoted variable references, the shell folds all the newlines together into single spaces, so that _diff_ winds up operating on just one line from each input source. When the content differs, the best _diff_ can do is report that that single line was changed.

Instead, by quoting these variable references, _echo_ receives and emits multiline content, and _diff_ can then report more granular differences at the line level as intended.