### PR TITLE
Cleaner diffs on test failure

### DIFF
--- a/jsonnet/jsonnet.bzl
+++ b/jsonnet/jsonnet.bzl
@@ -254,8 +254,6 @@ if [ "$OUTPUT" != "$GOLDEN" ]; then
   echo "FAIL (output mismatch): %s"
   echo "Diff:"
   diff <(echo $GOLDEN) <(echo $OUTPUT)
-  echo "Expected: $GOLDEN"
-  echo "Actual: $OUTPUT"
   exit 1
 fi
 """

--- a/jsonnet/jsonnet.bzl
+++ b/jsonnet/jsonnet.bzl
@@ -253,7 +253,7 @@ GOLDEN=$(%s %s)
 if [ "$OUTPUT" != "$GOLDEN" ]; then
   echo "FAIL (output mismatch): %s"
   echo "Diff:"
-  diff <(echo $GOLDEN) <(echo $OUTPUT)
+  diff <(echo "$GOLDEN") <(echo "$OUTPUT")
   exit 1
 fi
 """


### PR DESCRIPTION
This fixes the spacing being lost by wrapping the variable expansion in double quotes, and removes echoing the expected and actual output since it is not useful when dealing with large files.