### PR TITLE
Format "examples" BUILD file and adjust brittle test

### DIFF
--- a/examples/BUILD
+++ b/examples/BUILD
@@ -93,8 +93,8 @@ jsonnet_to_json_test(
 filegroup(
     name = "test_str_files",
     srcs = [
-        "file.txt",
         "WORKSPACE",
+        "file.txt",
     ],
 )
 
@@ -116,8 +116,8 @@ jsonnet_to_json_test(
     ],
     ext_code_files = [":test_code_files"],
     ext_str_file_vars = [
-        "test",
-        "workspace",
+        "0-workspace",
+        "1-test",
     ],
     ext_str_files = [":test_str_files"],
     golden = "extvar_filegroup_golden.json",
@@ -140,17 +140,20 @@ jsonnet_to_json_test(
     name = "extvar_stamp_test",
     size = "small",
     src = "extvar_stamp.jsonnet",
-    ext_strs = {
-      "non_stamp": "non_stamp",
-      "mydefine": "$(mydefine)",
-      "k8s": "{STABLE_K8S_CLUSTER}",
-    },
     ext_code = {
-      "complex": "{COMPLEX_JSON}",
-      "my_json": "{test: 'something'}",
+        "complex": "{COMPLEX_JSON}",
+        "my_json": "{test: 'something'}",
     },
-    stamp_keys = ["k8s", "complex"],
-    golden = "extvar_stamp_golden.json"
+    ext_strs = {
+        "non_stamp": "non_stamp",
+        "mydefine": "$(mydefine)",
+        "k8s": "{STABLE_K8S_CLUSTER}",
+    },
+    golden = "extvar_stamp_golden.json",
+    stamp_keys = [
+        "k8s",
+        "complex",
+    ],
 )
 
 jsonnet_to_json_test(

--- a/examples/extvar_filegroup.jsonnet
+++ b/examples/extvar_filegroup.jsonnet
@@ -1,8 +1,8 @@
-local test = std.extVar("test");
-local workspace = std.extVar("workspace");
-local codefile = std.extVar("codefile");
-local codefile2 = std.extVar("codefile2");
- {
+local test = std.extVar('1-test');
+local workspace = std.extVar('0-workspace');
+local codefile = std.extVar('codefile');
+local codefile2 = std.extVar('codefile2');
+{
   file1: test,
   file2: codefile.weather,
   file3: codefile2.weather,


### PR DESCRIPTION
The "extvar_files_test_filegroup" test expects that its "ext_str_file_vars" attribute's list will correspond to the "srcs" list elements in the "test_str_files" filegroup. However, when formatting the _BUILD_ file with the _buildifier_ tool, the natural ordering of these two lists compromises their alignment.

To keep them aligned, force an ordering onto the variable names in the "ext_str_file_vars" attribute, ensuring that "0-workspace" points to the _WORKSPACE_ file, and that "1-test" points to the _file.txt_ file.

This patch is a restatement of ff9f28802f27733be1c3036aaf6b107deeadc1c3, separated from #77.