### PR TITLE
Replace list(...) with ....to_list() for depsets.

### DIFF
--- a/jsonnet/jsonnet.bzl
+++ b/jsonnet/jsonnet.bzl
@@ -364,8 +364,8 @@ def _jsonnet_to_json_test_impl(ctx):
 
     test_inputs = (
         [ctx.file.src, ctx.executable.jsonnet] + golden_files +
-        list(transitive_data) +
-        list(depinfo.transitive_sources) +
+        transitive_data.to_list() +
+        depinfo.transitive_sources.to_list() +
         jsonnet_ext_str_files +
         jsonnet_ext_code_files +
         stamp_inputs


### PR DESCRIPTION
The old pattern did an implicit iteration over a depset which will be forbidden in the future since it is potentially expensive. The new to_list() call is still expensive but it will be more visible.