### PR TITLE
Upgrade to Jsonnet to version 0.12.1

### DIFF
--- a/jsonnet/jsonnet.bzl
+++ b/jsonnet/jsonnet.bzl
@@ -773,12 +773,13 @@ Example:
 
 def jsonnet_repositories():
     """Adds the external dependencies needed for the Jsonnet rules."""
+    version = "0.12.1"
     http_archive(
         name = "jsonnet",
-        sha256 = "c7c33f159a9391e90ab646b3b5fd671dab356d8563dc447ee824ecd77f4609f8",
-        strip_prefix = "jsonnet-0.11.2",
+        sha256 = "257c6de988f746cc90486d9d0fbd49826832b7a2f0dbdb60a515cc8a2596c950",
+        strip_prefix = "jsonnet-" + version,
         urls = [
-            "https://mirror.bazel.build/github.com/google/jsonnet/archive/v0.11.2.tar.gz",
-            "https://github.com/google/jsonnet/archive/v0.11.2.tar.gz",
+            "https://mirror.bazel.build/github.com/google/jsonnet/archive/v%s.tar.gz" % version,
+            "https://github.com/google/jsonnet/archive/v%s.tar.gz" % version,
         ],
     )


### PR DESCRIPTION
Jsonnet version 0.12.1 was released on 19 December 2018. As [this version's release notes](https://github.com/google/jsonnet/releases/tag/v0.12.1) only mention a small fix, it's worth also consulting [the release notes for the prior 0.12.0 release](https://github.com/google/jsonnet/releases/tag/v0.12.0).