### PR TITLE
Add tla_code_files attr

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,6 +340,15 @@ EOF
       </td>
     </tr>
     <tr>
+      <td><code>tla_code_files</code></td>
+      <td>
+        <code>Label-keyed String dict, optional</code>
+        <p>
+          Dict of labels referencing code files and a var name, passed to jsonnet via <code>--tla-code-file var=file</code>.
+        </p>
+      </td>
+    </tr>
+    <tr>
       <td><code>yaml_stream</code></td>
       <td>
         <code>bool, optional, default is False</code>

--- a/examples/BUILD
+++ b/examples/BUILD
@@ -90,6 +90,16 @@ jsonnet_to_json_test(
     golden = "extvar_files_golden.json",
 )
 
+jsonnet_to_json_test(
+    name = "tla_code_files_test",
+    size = "small",
+    src = "tla_code_files.jsonnet",
+    tla_code_files = {
+        "tla_code_file_input.json": "tla_file",
+    },
+    golden = "tla_code_files_golden.json",
+)
+
 filegroup(
     name = "test_str_files",
     srcs = [

--- a/examples/tla_code_file_input.json
+++ b/examples/tla_code_file_input.json
@@ -1,0 +1,4 @@
+{
+	"testvar": "example value"
+}
+

--- a/examples/tla_code_files.jsonnet
+++ b/examples/tla_code_files.jsonnet
@@ -1,0 +1,3 @@
+function(tla_file = {}) {
+  "tla_file_contents": tla_file,
+}

--- a/examples/tla_code_files_golden.json
+++ b/examples/tla_code_files_golden.json
@@ -1,0 +1,6 @@
+{
+	"tla_file_contents": {
+		"testvar": "example value"
+	}
+}
+


### PR DESCRIPTION
Add a jsonnet_to_json attribute to pass --tla-code-file arguments to
jsonnet. Fixes #98.

Fix jsonnet_to_json_test script condition syntax.