### PR TITLE
Use the Go Jsonnet port instead of the C++ port

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,19 @@ load("@jsonnet_go//bazel:deps.bzl", "jsonnet_go_dependencies")
 jsonnet_go_dependencies()
 ```
 
+## Jsonnet Port Selection
+
+By default, Bazel will use [the Go port](https://github.com/google/go-jsonnet) of Jsonnet. To use [the C++ port](https://github.com/google/jsonnet) of Jsonnet instead, invoke Bazel with the `--define jsonnet_port=cpp` command-line flag. To select the Go port explicitly, invoke Bazel with the `--define jsonnet_port=go` command-line flag.
+
+_bazel_ Flag | Jsonnet Port
+------------ | ------------
+(none)                     | Go
+`--define jsonnet_port=go` | Go
+`--define jsonnet_port=cpp`| C++
+
+Note that the primary development focus of the Jsonnet project is now with the Go port. This repository's support for using the C++ port is deprecated, and may be removed in a future release.
+
+
 <a name="#jsonnet_library"></a>
 ## jsonnet_library
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ external repositories for Jsonnet:
 ```python
 http_archive(
     name = "io_bazel_rules_jsonnet",
+    # TODO: Update this to reflect a later release.
     sha256 = "59bf1edb53bc6b5adb804fbfabd796a019200d4ef4dd5cc7bdee03acc7686806",
     strip_prefix = "rules_jsonnet-0.1.0",
     urls = ["https://github.com/bazelbuild/rules_jsonnet/archive/0.1.0.tar.gz"],
@@ -32,6 +33,14 @@ http_archive(
 load("@io_bazel_rules_jsonnet//jsonnet:jsonnet.bzl", "jsonnet_repositories")
 
 jsonnet_repositories()
+
+load("@jsonnet_go//bazel:repositories.bzl", "jsonnet_go_repositories")
+
+jsonnet_go_repositories()
+
+load("@jsonnet_go//bazel:deps.bzl", "jsonnet_go_dependencies")
+
+jsonnet_go_dependencies()
 ```
 
 <a name="#jsonnet_library"></a>

--- a/README.md
+++ b/README.md
@@ -45,15 +45,15 @@ jsonnet_go_dependencies()
 
 ## Jsonnet Port Selection
 
-By default, Bazel will use [the Go port](https://github.com/google/go-jsonnet) of Jsonnet. To use [the C++ port](https://github.com/google/jsonnet) of Jsonnet instead, invoke Bazel with the `--define jsonnet_port=cpp` command-line flag. To select the Go port explicitly, invoke Bazel with the `--define jsonnet_port=go` command-line flag.
+By default, Bazel will use [the C++ port](https://github.com/google/jsonnet) of Jsonnet. To use [the Go port](https://github.com/google/go-jsonnet) of Jsonnet instead, invoke Bazel with the `--define jsonnet_port=go` command-line flag. To select the C++ port explicitly, invoke Bazel with the `--define jsonnet_port=cpp` command-line flag.
 
 _bazel_ Flag | Jsonnet Port
 ------------ | ------------
-(none)                     | Go
-`--define jsonnet_port=go` | Go
+(none)                     | C++
 `--define jsonnet_port=cpp`| C++
+`--define jsonnet_port=go` | Go
 
-Note that the primary development focus of the Jsonnet project is now with the Go port. This repository's support for using the C++ port is deprecated, and may be removed in a future release.
+Note that the primary development focus of the Jsonnet project is now with the Go port. This repository's support for using the C++ port is deprecated, and may be removed in a future release. Before then, its default port will likely change from C++ to Go in the next release.
 
 
 <a name="#jsonnet_library"></a>

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -17,6 +17,14 @@ load("//jsonnet:jsonnet.bzl", "jsonnet_repositories")
 
 jsonnet_repositories()
 
+load("@jsonnet_go//bazel:repositories.bzl", "jsonnet_go_repositories")
+
+jsonnet_go_repositories()
+
+load("@jsonnet_go//bazel:deps.bzl", "jsonnet_go_dependencies")
+
+jsonnet_go_dependencies()
+
 # Used for documenting Jsonnet rules.
 # TODO: Move this to docs/WORKSPACE when recursive repositories are enabled.
 git_repository(

--- a/examples/BUILD
+++ b/examples/BUILD
@@ -50,6 +50,7 @@ jsonnet_to_json_test(
     src = "invalid.jsonnet",
     error = 1,
     golden = "invalid.out",
+    regex = 1,
 )
 
 jsonnet_to_json_test(

--- a/examples/BUILD
+++ b/examples/BUILD
@@ -7,7 +7,6 @@ package(default_visibility = ["//visibility:public"])
 load(
     "@io_bazel_rules_jsonnet//jsonnet:jsonnet.bzl",
     "jsonnet_library",
-    "jsonnet_to_json",
     "jsonnet_to_json_test",
 )
 

--- a/examples/invalid.out
+++ b/examples/invalid.out
@@ -1,2 +1,3 @@
 RUNTIME ERROR: Foo.
-	../examples/invalid.jsonnet:15:1-13	
+	../examples/invalid.jsonnet:15:1-13	$
+	During evaluation	

--- a/examples/invalid.out
+++ b/examples/invalid.out
@@ -1,3 +1,3 @@
-RUNTIME ERROR: Foo.
-	../examples/invalid.jsonnet:15:1-13	$
-	During evaluation	
+^RUNTIME ERROR: Foo\.
+	../examples/invalid\.jsonnet:15:1-13	($|\$
+	During evaluation	)

--- a/jsonnet/BUILD
+++ b/jsonnet/BUILD
@@ -8,3 +8,25 @@ py_binary(
     main = "stamper.py",
     visibility = ["//visibility:public"],
 )
+
+config_setting(
+    name = "port_cpp",
+    define_values = {
+        "jsonnet_port": "cpp",
+    },
+)
+
+config_setting(
+    name = "port_go",
+    define_values = {
+        "jsonnet_port": "go",
+    },
+)
+
+alias(
+    name = "jsonnet_tool",
+    actual = select({
+        "//jsonnet:port_cpp": "@jsonnet//cmd:jsonnet",
+        "//conditions:default": "@jsonnet_go//cmd/jsonnet",
+    }),
+)

--- a/jsonnet/BUILD
+++ b/jsonnet/BUILD
@@ -26,7 +26,7 @@ config_setting(
 alias(
     name = "jsonnet_tool",
     actual = select({
-        "//jsonnet:port_cpp": "@jsonnet//cmd:jsonnet",
-        "//conditions:default": "@jsonnet_go//cmd/jsonnet",
+        "//jsonnet:port_go": "@jsonnet_go//cmd/jsonnet",
+        "//conditions:default": "@jsonnet//cmd:jsonnet",
     }),
 )

--- a/jsonnet/jsonnet.bzl
+++ b/jsonnet/jsonnet.bzl
@@ -800,7 +800,7 @@ def jsonnet_repositories():
     git_repository(
         name = "jsonnet_go",
         remote = "https://github.com/google/go-jsonnet",
-        commit = "4996d464715f0633f05ae7c056eb846209266907",
+        commit = "13437c69e1834da8ca99dc8471adc97d0eb776d5",
         init_submodules = True,
-        shallow_since = "1562238587 +0200",
+        shallow_since = "1566677218 +0200",
     )

--- a/jsonnet/jsonnet.bzl
+++ b/jsonnet/jsonnet.bzl
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 """Jsonnet Rules
 
@@ -272,7 +273,7 @@ if [ "$OUTPUT" != "$GOLDEN" ]; then
   echo "FAIL (output mismatch): %s"
   echo "Diff:"
   diff <(echo "$GOLDEN") <(echo "$OUTPUT")
-  if [ %s = true]; then
+  if [ %s = true ]; then
     echo "Expected: $GOLDEN"
     echo "Actual: $OUTPUT"
   fi
@@ -284,7 +285,7 @@ _REGEX_DIFF_COMMAND = """
 GOLDEN_REGEX=$(%s %s)
 if [[ ! "$OUTPUT" =~ $GOLDEN_REGEX ]]; then
   echo "FAIL (regex mismatch): %s"
-  if [ %s = true]; then
+  if [ %s = true ]; then
     echo "Output: $OUTPUT"
   fi
   exit 1
@@ -403,7 +404,7 @@ _jsonnet_common_attrs = {
     ),
     "imports": attr.string_list(),
     "jsonnet": attr.label(
-        default = Label("@jsonnet_go//cmd/jsonnet"),
+        default = Label("//jsonnet:jsonnet_tool"),
         cfg = "host",
         executable = True,
         allow_single_file = True,
@@ -788,6 +789,14 @@ Example:
 
 def jsonnet_repositories():
     """Adds the external dependencies needed for the Jsonnet rules."""
+    http_archive(
+        name = "jsonnet",
+        sha256 = "f6f0c4ea333f3423f1a7237a8a107c589354c38be8a2a438198f9f7c69b77596",
+        strip_prefix = "jsonnet-0.13.0",
+        urls = [
+            "https://github.com/google/jsonnet/archive/v0.13.0.tar.gz",
+        ],
+    )
     git_repository(
         name = "jsonnet_go",
         remote = "https://github.com/google/go-jsonnet",

--- a/jsonnet/jsonnet.bzl
+++ b/jsonnet/jsonnet.bzl
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 
 """Jsonnet Rules
 
@@ -403,7 +403,7 @@ _jsonnet_common_attrs = {
     ),
     "imports": attr.string_list(),
     "jsonnet": attr.label(
-        default = Label("@jsonnet//cmd:jsonnet"),
+        default = Label("@jsonnet_go//cmd/jsonnet"),
         cfg = "host",
         executable = True,
         allow_single_file = True,
@@ -788,11 +788,10 @@ Example:
 
 def jsonnet_repositories():
     """Adds the external dependencies needed for the Jsonnet rules."""
-    http_archive(
-        name = "jsonnet",
-        sha256 = "f6f0c4ea333f3423f1a7237a8a107c589354c38be8a2a438198f9f7c69b77596",
-        strip_prefix = "jsonnet-0.13.0",
-        urls = [
-            "https://github.com/google/jsonnet/archive/v0.13.0.tar.gz",
-        ],
+    git_repository(
+        name = "jsonnet_go",
+        remote = "https://github.com/google/go-jsonnet",
+        commit = "4996d464715f0633f05ae7c056eb846209266907",
+        init_submodules = True,
+        shallow_since = "1562238587 +0200",
     )


### PR DESCRIPTION
The Jsonnet project's development focus has shifted to [the Go language port](https://github.com/google/go-jsonnet), with all the recent performance optimizations landing there. Change _rules_jsonnet_ to use the Go port instead of the C++ port unconditionally.

While it would be possible to expose this choice to users of this package, perhaps by way of introducing a sibling function to `jsonnet_repositories`, or introducing a parameter to that function, I don't think it's worth the maintenance burden to do so.

@sparkprime and @sbarzowski, your guidance would be welcome here.