### PR TITLE
Fix syntax error in README example code

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,7 +264,7 @@ local foo = import "foo.jsonnet";
 jsonnet_to_json(
   name = "...",
   ext_strs = {
-    cluster = "{CLUSTER}"
+    "cluster": "{CLUSTER}"
   },
   stamp_keys = ["cluster"]
 )


### PR DESCRIPTION
I believe this currently has [incorrect Starlark `dict` syntax](https://docs.bazel.build/versions/master/skylark/lib/dict.html).