### PR TITLE
Change default Jsonnet port from C++ to Go

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,16 +44,15 @@ jsonnet_go_dependencies()
 
 ## Jsonnet Port Selection
 
-By default, Bazel will use [the C++ port](https://github.com/google/jsonnet) of Jsonnet. To use [the Go port](https://github.com/google/go-jsonnet) of Jsonnet instead, invoke Bazel with the `--define jsonnet_port=go` command-line flag. To select the C++ port explicitly, invoke Bazel with the `--define jsonnet_port=cpp` command-line flag.
+By default, Bazel will use [the Go port](https://github.com/google/go-jsonnet) of Jsonnet. To use [the C++ port](https://github.com/google/jsonnet) of Jsonnet instead, invoke Bazel with the `--define jsonnet_port=cpp` command-line flag. To select the Go port explicitly, invoke Bazel with the `--define jsonnet_port=go` command-line flag.
 
 _bazel_ Flag | Jsonnet Port
 ------------ | ------------
-(none)                     | C++
+(none)                     | Go
 `--define jsonnet_port=cpp`| C++
 `--define jsonnet_port=go` | Go
 
-Note that the primary development focus of the Jsonnet project is now with the Go port. This repository's support for using the C++ port is deprecated, and may be removed in a future release. Before then, its default port will likely change from C++ to Go in the next release.
-
+Note that the primary development focus of the Jsonnet project is now with the Go port. This repository's support for using the C++ port is deprecated, and may be removed in a future release.
 
 <a name="#jsonnet_library"></a>
 ## jsonnet_library

--- a/jsonnet/BUILD
+++ b/jsonnet/BUILD
@@ -26,7 +26,7 @@ config_setting(
 alias(
     name = "jsonnet_tool",
     actual = select({
-        "//jsonnet:port_go": "@jsonnet_go//cmd/jsonnet",
-        "//conditions:default": "@jsonnet//cmd:jsonnet",
+        "//jsonnet:port_cpp": "@jsonnet//cmd:jsonnet",
+        "//conditions:default": "@jsonnet_go//cmd/jsonnet",
     }),
 )


### PR DESCRIPTION
As threatened in #113 [in mid-2019](https://github.com/bazelbuild/rules_jsonnet/pull/113#issue-293362748), change the default Jsonnet tool to the Go port, leaving the C++ port available for selection via the `--define` command-line flag to set the "jsonnet_port" build variable accordingly.

We agreed to [retain the C++ port as the default for at least one more release]( https://github.com/bazelbuild/rules_jsonnet/pull/113#issue-293362748). I'm not sure not sure whether that meant one more since [we introduced support for the Go port](https://github.com/bazelbuild/rules_jsonnet/releases/tag/0.2.0).