### PR TITLE
WIP: Support sjsonnet as an alternative tool 

### DIFF
--- a/jsonnet/BUILD
+++ b/jsonnet/BUILD
@@ -23,10 +23,18 @@ config_setting(
     },
 )
 
+config_setting(
+    name = "port_scala",
+    define_values = {
+        "jsonnet_port": "scala",
+    },
+)
+
 alias(
     name = "jsonnet_tool",
     actual = select({
         "//jsonnet:port_cpp": "@jsonnet//cmd:jsonnet",
+        "//jsonnet:port_scala": "//tools/sjsonnet:sjsonnet_bin",
         "//conditions:default": "@jsonnet_go//cmd/jsonnet",
     }),
 )

--- a/jsonnet/jsonnet.bzl
+++ b/jsonnet/jsonnet.bzl
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive", "http_file", "http_jar")
 
 """Jsonnet Rules
 
@@ -182,11 +182,8 @@ def _jsonnet_to_json_impl(ctx):
 
     other_args = ctx.attr.extra_args + (["-y"] if ctx.attr.yaml_stream else [])
 
-    command = (
-        [
-            "set -e;",
-            toolchain.jsonnet_path,
-        ] + ["-J %s" % im for im in _add_prefix_to_imports(ctx.label, ctx.attr.imports)] +
+    exec_args = list(
+        ["-J %s" % im for im in _add_prefix_to_imports(ctx.label, ctx.attr.imports)] +
         ["-J %s" % im for im in depinfo.imports.to_list()] + [
             "-J .",
             "-J %s" % ctx.genfiles_dir.path,
@@ -215,14 +212,14 @@ def _jsonnet_to_json_impl(ctx):
     # JSON to stdout, which is redirected into a single JSON output file.
     if len(ctx.attr.outs) > 1 or ctx.attr.multiple_outputs:
         outputs += ctx.outputs.outs
-        command += ["-m", ctx.outputs.outs[0].dirname, ctx.file.src.path]
+        exec_args += ["-m", ctx.outputs.outs[0].dirname, ctx.file.src.path]
     elif len(ctx.attr.outs) > 1:
         fail("Only one file can be specified in outs if multiple_outputs is " +
              "not set.")
     else:
         compiled_json = ctx.outputs.outs[0]
         outputs += [compiled_json]
-        command += [ctx.file.src.path, "-o", compiled_json.path]
+        exec_args += [ctx.file.src.path, "-o", compiled_json.path]
 
     transitive_data = depset(transitive = [dep.data_runfiles.files for dep in ctx.attr.deps] +
                                           [l.files for l in jsonnet_tla_code_files.keys()])
@@ -245,15 +242,16 @@ def _jsonnet_to_json_impl(ctx):
         depinfo.transitive_sources.to_list()
     )
 
-    tools = [ctx.executable.jsonnet]
+    # Remove spaces from args, break into multiple args
+    exec_args = " ".join(exec_args).split(" ")
 
-    ctx.actions.run_shell(
+    ctx.actions.run(
         inputs = compile_inputs + stamp_inputs,
-        tools = tools,
+        tools = [ctx.executable.jsonnet],
         outputs = outputs,
         mnemonic = "Jsonnet",
-        command = " ".join(command),
-        use_default_shell_env = True,
+        executable = ctx.executable.jsonnet.path,
+        arguments = exec_args,
         progress_message = "Compiling Jsonnet to JSON for " + ctx.label.name,
     )
 
@@ -416,7 +414,6 @@ _jsonnet_common_attrs = {
         default = Label("//jsonnet:jsonnet_tool"),
         cfg = "host",
         executable = True,
-        allow_single_file = True,
     ),
     "deps": attr.label_list(
         providers = ["transitive_jsonnet_files"],
@@ -813,4 +810,10 @@ def jsonnet_repositories():
         commit = "70a6b3d419d9ee16a144345c35e0305052c6f2d9",  # v0.15.0
         shallow_since = "1581289066 +0100",
         init_submodules = True,
+    )
+    # TODO: Consider building sjsonnet with rules_scala / rules_jvm_external
+    http_jar(
+        name = "sjsonnet",
+        url = "https://github.com/databricks/sjsonnet/releases/download/0.2.4/sjsonnet.jar",
+        sha256 = "956b8afef505dfa0a106b0519eb99602851b06428c8384b39055c6a3a358f685"
     )

--- a/jsonnet/jsonnet.bzl
+++ b/jsonnet/jsonnet.bzl
@@ -397,12 +397,15 @@ def _jsonnet_to_json_test_impl(ctx):
         stamp_inputs
     )
 
-    return struct(
-        runfiles = ctx.runfiles(
+    self_runfiles = ctx.runfiles(
             files = test_inputs,
             transitive_files = transitive_data,
             collect_data = True,
-        ),
+        )
+    tool_runfiles = ctx.attr.jsonnet[DefaultInfo].default_runfiles
+
+    return struct(
+        runfiles = self_runfiles.merge(tool_runfiles)
     )
 
 _jsonnet_common_attrs = {

--- a/tools/sjsonnet/BUILD
+++ b/tools/sjsonnet/BUILD
@@ -1,0 +1,18 @@
+
+# java_toolchain(
+#     name = "java_toolchain",
+#     encoding = "UTF-8",
+#     source_version = "8",
+#     target_version = "8",
+#     misc = [
+#         "-extra_checks:on",
+#     ],
+# )
+
+java_binary(
+    name = "sjsonnet_bin",
+    runtime_deps = ["@sjsonnet//jar"],
+    main_class = "sjsonnet.SjsonnetMain",
+    visibility = ["//visibility:public"],
+    create_executable = True,
+)


### PR DESCRIPTION
This adds the option to add `--define jsonnet_port=scala` to bazel args to enable the use of the sjsonnet interpreter instead of the default go-jsonnet.

Progress 18th Jun: Currently there are some incompatibilities with the sjsonnet tool causing it to fail the test suite.

```
@examples//:extvar_env_test                                              FAILED in 0.8s
    ERROR   .external/examples/extvar_env_test (0.0s)
@examples//:extvar_files_test                                            FAILED in 0.8s
    ERROR   .external/examples/extvar_files_test (0.0s)
@examples//:extvar_files_test_filegroup                                  FAILED in 0.8s
    ERROR   .external/examples/extvar_files_test_filegroup (0.0s)
@examples//:extvar_stamp_test                                            FAILED in 0.8s
    ERROR   .external/examples/extvar_stamp_test (0.0s)
@examples//:invalid_test                                                 FAILED in 1.0s
    ERROR   .external/examples/invalid_test (0.0s)
@examples//:strings_test                                                 FAILED in 0.8s
    ERROR   .external/examples/strings_test (0.0s)
Test cases: finished with 10 passing and 6 failing out of 16 test cases

INFO: Build completed, 6 tests FAILED, 7 total actions

```
Addresses https://github.com/bazelbuild/rules_jsonnet/issues/132