### PR TITLE
Write multiple_outputs manifest to a file

### DIFF
--- a/jsonnet/jsonnet.bzl
+++ b/jsonnet/jsonnet.bzl
@@ -214,8 +214,9 @@ def _jsonnet_to_json_impl(ctx):
     # -m flag for multiple outputs. Otherwise, jsonnet will write the resulting
     # JSON to stdout, which is redirected into a single JSON output file.
     if len(ctx.attr.outs) > 1 or ctx.attr.multiple_outputs:
-        outputs += ctx.outputs.outs
-        command += ["-m", ctx.outputs.outs[0].dirname, ctx.file.src.path]
+        output_manifest = ctx.actions.declare_file("_%s_outs.mf" % ctx.label.name)
+        outputs += ctx.outputs.outs + [output_manifest]
+        command += ["-m", ctx.outputs.outs[0].dirname, ctx.file.src.path, "-o", output_manifest.path]
     elif len(ctx.attr.outs) > 1:
         fail("Only one file can be specified in outs if multiple_outputs is " +
              "not set.")


### PR DESCRIPTION
This avoids writing a long list of files to stdout and therefore to the Bazel log.
Successful Bazel actions should generally be silent.

https://github.com/google/go-jsonnet/blob/v0.14.0/cmd/jsonnet/cmd.go#L351-L360 is the code showing where the underlying tool
calls this output a "manifest" and indicates that os.Stdout is used if the -o flag is absent.

Fixes #138