### PR TITLE
Remove ubuntu1604 from presubmit.yml

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -1,23 +1,16 @@
 ---
 platforms:
-  ubuntu1604:
-    build_targets:
-    - "..."
-    - "@examples//..."
-    test_targets:
-    - "..."
-    - "@examples//..."
   ubuntu1804:
     build_targets:
-    - "..."
+    - "//..."
     - "@examples//..."
     test_targets:
-    - "..."
+    - "//..."
     - "@examples//..."
   macos:
     build_targets:
-    - "..."
+    - "//..."
     - "@examples//..."
     test_targets:
-    - "..."
+    - "//..."
     - "@examples//..."


### PR DESCRIPTION
Ubuntu 16.04 is end-of-life, we're going to remove it from Bazel CI.