### PR TITLE
Change name of @jsonnet_go external reference to @google_jsonnet_go.

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,11 +33,11 @@ load("@io_bazel_rules_jsonnet//jsonnet:jsonnet.bzl", "jsonnet_repositories")
 
 jsonnet_repositories()
 
-load("@jsonnet_go//bazel:repositories.bzl", "jsonnet_go_repositories")
+load("@google_jsonnet_go//bazel:repositories.bzl", "jsonnet_go_repositories")
 
 jsonnet_go_repositories()
 
-load("@jsonnet_go//bazel:deps.bzl", "jsonnet_go_dependencies")
+load("@google_jsonnet_go//bazel:deps.bzl", "jsonnet_go_dependencies")
 
 jsonnet_go_dependencies()
 ```

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -17,11 +17,11 @@ load("//jsonnet:jsonnet.bzl", "jsonnet_repositories")
 
 jsonnet_repositories()
 
-load("@jsonnet_go//bazel:repositories.bzl", "jsonnet_go_repositories")
+load("@google_jsonnet_go//bazel:repositories.bzl", "jsonnet_go_repositories")
 
 jsonnet_go_repositories()
 
-load("@jsonnet_go//bazel:deps.bzl", "jsonnet_go_dependencies")
+load("@google_jsonnet_go//bazel:deps.bzl", "jsonnet_go_dependencies")
 
 jsonnet_go_dependencies()
 

--- a/jsonnet/BUILD
+++ b/jsonnet/BUILD
@@ -27,6 +27,6 @@ alias(
     name = "jsonnet_tool",
     actual = select({
         "//jsonnet:port_cpp": "@jsonnet//cmd:jsonnet",
-        "//conditions:default": "@jsonnet_go//cmd/jsonnet",
+        "//conditions:default": "@google_jsonnet_go//cmd/jsonnet",
     }),
 )

--- a/jsonnet/jsonnet.bzl
+++ b/jsonnet/jsonnet.bzl
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 """Jsonnet Rules
@@ -847,10 +846,10 @@ def jsonnet_repositories():
             "https://github.com/google/jsonnet/archive/v0.17.0.tar.gz",
         ],
     )
-    git_repository(
-        name = "jsonnet_go",
-        remote = "https://github.com/google/go-jsonnet",
-        commit = "0d1d4cb81244b9466c4c93f790acca01d260245e",  # v0.17.0
-        shallow_since = "1606056352 +0100",
-        init_submodules = True,
+
+    http_archive(
+        name = "google_jsonnet_go",
+        sha256 = "4fd04d0c9e38572ef388d28ea6b1ac151b8a9a5026ff94e3a68bdbc18c4db38a",
+        strip_prefix = "go-jsonnet-0.17.0",
+        urls = ["https://github.com/google/go-jsonnet/archive/refs/tags/v0.17.0.tar.gz"],
     )


### PR DESCRIPTION
The repository at https://github.com/google/go-jsonnet has a WORKSPACE file with `workspace(name = "google_jsonnet_go")` header.

Based on Bazel's recommendations, the external repository's name (`http_archive`'s or `git_repository`'s `name=` argument) should match the workspace name.
This will make it easier to make sure that a project that depends both on go-jsonnet and rules_jsonnet will only have 1 version of the go-jsonnet binaries in play.

Also moved to using `http_archive` (rather than `git_repository`) to be in line with [best practices](https://docs.bazel.build/versions/main/external.html#repository-rules).