### PR TITLE
Fix old interface to depset call

### DIFF
--- a/jsonnet/jsonnet.bzl
+++ b/jsonnet/jsonnet.bzl
@@ -255,7 +255,7 @@ def _jsonnet_to_json_impl(ctx):
     runfiles = ctx.runfiles(
         collect_data = True,
         files = files,
-        transitive_files = depset(transitive_data),
+        transitive_files = transitive_data,
     )
 
     compile_inputs = (


### PR DESCRIPTION
Fixed downstream failures:
https://buildkite.com/bazel/bazel-at-head-plus-downstream/builds/2241#2a903ba2-1028-4f4b-b2d4-fce20c98be62