### PR TITLE
Update readme to 0.4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,9 +25,9 @@ external repositories for Jsonnet:
 ```python
 http_archive(
     name = "io_bazel_rules_jsonnet",
-    sha256 = "7f51f859035cd98bcf4f70dedaeaca47fe9fbae6b199882c516d67df416505da",
-    strip_prefix = "rules_jsonnet-0.3.0",
-    urls = ["https://github.com/bazelbuild/rules_jsonnet/archive/0.3.0.tar.gz"],
+    sha256 = "d20270872ba8d4c108edecc9581e2bb7f320afab71f8caa2f6394b5202e8a2c3",
+    strip_prefix = "rules_jsonnet-0.4.0",
+    urls = ["https://github.com/bazelbuild/rules_jsonnet/archive/0.4.0.tar.gz"],
 )
 load("@io_bazel_rules_jsonnet//jsonnet:jsonnet.bzl", "jsonnet_repositories")
 


### PR DESCRIPTION
Update README.md to specify 0.4.0 which is compatible with bazel 5.
README was already partially updated for that with `@jsonnet_go` -> `@google_jsonnet_go` change which changes going `0.3.0` -> `0.4.0`