### PR TITLE
Perform proper string concatenation in jsonnet_to_json()

### DIFF
--- a/examples/BUILD
+++ b/examples/BUILD
@@ -4,7 +4,7 @@ package(default_visibility = ["//visibility:public"])
 # for jsonnet rules.  The BUILD rules should not contain any jsonnet_to_json
 # rules as this is redundant with jsonnet_to_json_test rules.
 
-load("@rules_jsonnet//jsonnet:jsonnet.bzl", "jsonnet_library", "jsonnet_to_json_test")
+load("@rules_jsonnet//jsonnet:jsonnet.bzl", "jsonnet_library", "jsonnet_to_json", "jsonnet_to_json_test")
 
 jsonnet_library(
     name = "workflow",
@@ -222,6 +222,14 @@ jsonnet_to_json_test(
     src = "yaml_stream.jsonnet",
     golden = "yaml_stream_golden.yaml",
     yaml_stream = 1,
+)
+
+jsonnet_to_json(
+    name = "imports_build",
+    src = "imports.jsonnet",
+    outs = ["imports.json"],
+    imports = ["imports"],
+    deps = ["//imports:a"],
 )
 
 jsonnet_to_json_test(

--- a/jsonnet/jsonnet.bzl
+++ b/jsonnet/jsonnet.bzl
@@ -221,7 +221,7 @@ def _jsonnet_to_json_impl(ctx):
             toolchain.jsonnet_path,
         ] +
         ["-J " + shell.quote(im) for im in _get_import_paths(ctx.label, [ctx.file.src], ctx.attr.imports)] +
-        ["-J " % shell.quote(im) for im in depinfo.imports.to_list()] +
+        ["-J " + shell.quote(im) for im in depinfo.imports.to_list()] +
         other_args +
         ["--ext-str %s=%s" %
          (_quote(key), _quote(val)) for key, val in jsonnet_ext_strs.items()] +


### PR DESCRIPTION
It looks like #182 introduced a small regression, where '%' was used instead of '+' to perform string concatenation. This went by unnoticed, because we seemingly don't have any testing coverage for plain jsonnet_to_json().

Solve this by duplicating one of the import tests that was affected by this to invoke plain jsonnet_to_json().