### PR TITLE
Use unified diff output in jsonnet_to_json_test()

### DIFF
--- a/jsonnet/jsonnet.bzl
+++ b/jsonnet/jsonnet.bzl
@@ -335,7 +335,7 @@ GOLDEN=$(%s %s)
 if [ "$OUTPUT" != "$GOLDEN" ]; then
   echo "FAIL (output mismatch): %s"
   echo "Diff:"
-  diff <(echo "$GOLDEN") <(echo "$OUTPUT")
+  diff -u <(echo "$GOLDEN") <(echo "$OUTPUT")
   if [ %s = true ]; then
     echo "Expected: $GOLDEN"
     echo "Actual: $OUTPUT"


### PR DESCRIPTION
Unified diffs are used far more commonly than the context diffs that the diff(1) utility generates by default.

Fixes: #161