### PR TITLE
Correct the name of the resulting source tarball

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,4 +35,4 @@ jobs:
           generate_release_notes: true
           body_path: release_notes.txt
           fail_on_unmatched_files: true
-          files: rules_python-*.tar.gz
+          files: rules_jsonnet-*.tar.gz


### PR DESCRIPTION
Even though I was capable of testing the shell script that constructs the source tarball, I couldn't test the release workflow end to end. It looks like I left something from rules_python behind.