### PR TITLE
Simply link to the releases page for setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,35 +19,8 @@ These are build rules for working with [Jsonnet][jsonnet] files with Bazel.
 
 ## Setup
 
-To use the Jsonnet rules, add the following to your `MODULE.bazel` file:
-
-```python
-bazel_dep(name = "rules_jsonnet", version = "0.5.0")
-```
-
-If you are using an older version of Bazel that does not support Bzlmod,
-add the following to your `WORKSPACE` file to add the external
-repositories for Jsonnet:
-
-```python
-http_archive(
-    name = "io_bazel_rules_jsonnet",
-    sha256 = "c51ba0dba41d667fa5c64e56e252ba54be093e5ae764af6470dabca901f373eb",
-    strip_prefix = "rules_jsonnet-0.5.0",
-    urls = ["https://github.com/bazelbuild/rules_jsonnet/archive/0.5.0.tar.gz"],
-)
-load("@io_bazel_rules_jsonnet//jsonnet:jsonnet.bzl", "jsonnet_repositories")
-
-jsonnet_repositories()
-
-load("@google_jsonnet_go//bazel:repositories.bzl", "jsonnet_go_repositories")
-
-jsonnet_go_repositories()
-
-load("@google_jsonnet_go//bazel:deps.bzl", "jsonnet_go_dependencies")
-
-jsonnet_go_dependencies()
-```
+To use the Jsonnet rules as part of your Bazel project, please follow the
+instructions on [the releases page](https://github.com/bazelbuild/rules_jsonnet/releases).
 
 ## Jsonnet Port Selection
 

--- a/docs/jsonnet.md
+++ b/docs/jsonnet.md
@@ -8,35 +8,8 @@ These are build rules for working with [Jsonnet][jsonnet] files with Bazel.
 
 ## Setup
 
-To use the Jsonnet rules, add the following to your `MODULE.bazel` file:
-
-```python
-bazel_dep(name = "rules_jsonnet", version = "0.5.0")
-```
-
-If you are using an older version of Bazel that does not support Bzlmod,
-add the following to your `WORKSPACE` file to add the external
-repositories for Jsonnet:
-
-```python
-http_archive(
-    name = "io_bazel_rules_jsonnet",
-    sha256 = "c51ba0dba41d667fa5c64e56e252ba54be093e5ae764af6470dabca901f373eb",
-    strip_prefix = "rules_jsonnet-0.5.0",
-    urls = ["https://github.com/bazelbuild/rules_jsonnet/archive/0.5.0.tar.gz"],
-)
-load("@io_bazel_rules_jsonnet//jsonnet:jsonnet.bzl", "jsonnet_repositories")
-
-jsonnet_repositories()
-
-load("@google_jsonnet_go//bazel:repositories.bzl", "jsonnet_go_repositories")
-
-jsonnet_go_repositories()
-
-load("@google_jsonnet_go//bazel:deps.bzl", "jsonnet_go_dependencies")
-
-jsonnet_go_dependencies()
-```
+To use the Jsonnet rules as part of your Bazel project, please follow the
+instructions on [the releases page](https://github.com/bazelbuild/rules_jsonnet/releases).
 
 <a id="jsonnet_library"></a>
 

--- a/jsonnet/jsonnet.bzl
+++ b/jsonnet/jsonnet.bzl
@@ -20,35 +20,8 @@ These are build rules for working with [Jsonnet][jsonnet] files with Bazel.
 
 ## Setup
 
-To use the Jsonnet rules, add the following to your `MODULE.bazel` file:
-
-```python
-bazel_dep(name = "rules_jsonnet", version = "0.5.0")
-```
-
-If you are using an older version of Bazel that does not support Bzlmod,
-add the following to your `WORKSPACE` file to add the external
-repositories for Jsonnet:
-
-```python
-http_archive(
-    name = "io_bazel_rules_jsonnet",
-    sha256 = "c51ba0dba41d667fa5c64e56e252ba54be093e5ae764af6470dabca901f373eb",
-    strip_prefix = "rules_jsonnet-0.5.0",
-    urls = ["https://github.com/bazelbuild/rules_jsonnet/archive/0.5.0.tar.gz"],
-)
-load("@io_bazel_rules_jsonnet//jsonnet:jsonnet.bzl", "jsonnet_repositories")
-
-jsonnet_repositories()
-
-load("@google_jsonnet_go//bazel:repositories.bzl", "jsonnet_go_repositories")
-
-jsonnet_go_repositories()
-
-load("@google_jsonnet_go//bazel:deps.bzl", "jsonnet_go_dependencies")
-
-jsonnet_go_dependencies()
-```
+To use the Jsonnet rules as part of your Bazel project, please follow the
+instructions on [the releases page](https://github.com/bazelbuild/rules_jsonnet/releases).
 """
 
 load("@bazel_skylib//lib:paths.bzl", "paths")


### PR DESCRIPTION
Because we have now automated our release setup, we no longer need to manually patch up documentation whenever we release a new version of rules_jsonnet.