### PR TITLE
Make multiple output files in nested directories work

### DIFF
--- a/examples/BUILD
+++ b/examples/BUILD
@@ -273,3 +273,21 @@ jsonnet_to_json(
     src = "out_dir.jsonnet",
     out_dir = "out_dir.output",
 )
+
+jsonnet_to_json(
+    name = "multiple_outs_toplevel",
+    src = "multiple_outs.jsonnet",
+    outs = [
+        "dir1/file1.json",
+        "dir2/file2.json",
+    ],
+)
+
+jsonnet_to_json(
+    name = "multiple_outs_nested",
+    src = "multiple_outs.jsonnet",
+    outs = [
+        "nested/dir1/file1.json",
+        "nested/dir2/file2.json",
+    ],
+)

--- a/examples/multiple_outs.jsonnet
+++ b/examples/multiple_outs.jsonnet
@@ -1,0 +1,4 @@
+{
+  'dir1/file1.json': {},
+  'dir2/file2.json': {},
+}

--- a/examples/out_dir.jsonnet
+++ b/examples/out_dir.jsonnet
@@ -1,4 +1,5 @@
 {
   'hello.txt': 'Hello, Bazel!',
   'goodbye.txt': 'Goodbye, Bazel!',
+  'nested/nested.txt': 'This file is in a nested directory.',
 }


### PR DESCRIPTION
Right now we assume that what needs to be provided to the -m flag is the directory name of the first output file. But it's completely valid for output files to be spread out across directories.

This change extends this logic by computing the leading part of the directory name that is shared by all output files.

Fixes: #56