### PR TITLE
Refine #190

### DIFF
--- a/examples/BUILD
+++ b/examples/BUILD
@@ -291,3 +291,12 @@ jsonnet_to_json(
         "nested/dir2/file2.json",
     ],
 )
+
+jsonnet_to_json(
+    name = "multiple_outs_nested_asymmetric",
+    src = "multiple_outs_nested_asymmetric.jsonnet",
+    outs = [
+        "multiple_outs_nested_asymmetric/aaaaa/file.json",
+        "multiple_outs_nested_asymmetric/file.json",
+    ],
+)

--- a/examples/multiple_outs_nested_asymmetric.jsonnet
+++ b/examples/multiple_outs_nested_asymmetric.jsonnet
@@ -1,0 +1,4 @@
+{
+  'aaaaa/file.json': {},
+  'file.json': {},
+}

--- a/jsonnet/jsonnet.bzl
+++ b/jsonnet/jsonnet.bzl
@@ -242,7 +242,9 @@ def _jsonnet_to_json_impl(ctx):
         # directory name that is shared by all output files.
         base_dirname = ctx.outputs.outs[0].dirname.split("/")
         for output in ctx.outputs.outs[1:]:
-            for i, (part1, part2) in enumerate(zip(base_dirname, output.dirname.split("/"))):
+            component_pairs = zip(base_dirname, output.dirname.split("/"))
+            base_dirname = base_dirname[:len(component_pairs)]
+            for i, (part1, part2) in enumerate(component_pairs):
                 if part1 != part2:
                     base_dirname = base_dirname[:i]
                     break


### PR DESCRIPTION
Even though the provided test case did work for situations where files had mismatching directory names, it didn't work well if one of the directory names was the prefix of the other.