### PR TITLE
Bazel toolchain support

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -3,6 +3,10 @@ matrix:
   platform:
   - ubuntu2204
   - macos
+  toolchain:
+  - "@rules_jsonnet//jsonnet:go_jsonnet_toolchain"
+  - "@rules_jsonnet//jsonnet:cpp_jsonnet_toolchain"
+  - "@rules_jsonnet//jsonnet:rust_jsonnet_toolchain"
 
 tasks:
   rules_jsonnet:
@@ -16,8 +20,7 @@ tasks:
     platform: ${{ platform }}
     working_directory: docs
     test_flags:
-    - --define
-    - jsonnet_port=${{ jsonnet_port }}
+    - "--extra_toolchains=${{ toolchain }}"
     test_targets:
     - //...
 
@@ -26,7 +29,6 @@ tasks:
     platform: ${{ platform }}
     working_directory: examples
     test_flags:
-    - --define
-    - jsonnet_port=${{ jsonnet_port }}
+    - "--extra_toolchains=${{ toolchain }}"
     test_targets:
     - //...

--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -3,10 +3,6 @@ matrix:
   platform:
   - ubuntu2204
   - macos
-  toolchain:
-  - "@rules_jsonnet//jsonnet:go_jsonnet_toolchain"
-  - "@rules_jsonnet//jsonnet:cpp_jsonnet_toolchain"
-  - "@rules_jsonnet//jsonnet:rust_jsonnet_toolchain"
 
 tasks:
   rules_jsonnet:
@@ -19,16 +15,32 @@ tasks:
     name: docs
     platform: ${{ platform }}
     working_directory: docs
-    test_flags:
-    - "--extra_toolchains=${{ toolchain }}"
     test_targets:
     - //...
 
-  examples:
+  examples_go:
     name: examples
     platform: ${{ platform }}
     working_directory: examples
     test_flags:
-    - "--extra_toolchains=${{ toolchain }}"
+    - "--extra_toolchains=@rules_jsonnet//jsonnet:go_jsonnet_toolchain"
+    test_targets:
+    - //...
+
+  examples_cpp:
+    name: examples
+    platform: ${{ platform }}
+    working_directory: examples
+    test_flags:
+    - "--extra_toolchains=@rules_jsonnet//jsonnet:cpp_jsonnet_toolchain"
+    test_targets:
+    - //...
+
+  examples_rust:
+    name: examples
+    platform: ${{ platform }}
+    working_directory: examples
+    test_flags:
+    - "--extra_toolchains=@rules_jsonnet//jsonnet:rust_jsonnet_toolchain"
     test_targets:
     - //...

--- a/.github/workflows/create_archive_and_notes.sh
+++ b/.github/workflows/create_archive_and_notes.sh
@@ -58,5 +58,7 @@ jsonnet_go_repositories()
 load("@google_jsonnet_go//bazel:deps.bzl", "jsonnet_go_dependencies")
 
 jsonnet_go_dependencies()
+
+register_toolchains("@io_bazel_rules_jsonnet//jsonnet:go_jsonnet_toolchain")
 \`\`\`
 EOF

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -7,3 +7,50 @@ module(
 bazel_dep(name = "bazel_skylib", version = "1.5.0")
 bazel_dep(name = "jsonnet", version = "0.20.0")
 bazel_dep(name = "jsonnet_go", version = "0.20.0", repo_name = "google_jsonnet_go")
+
+bazel_dep(name = "rules_rust", version = "0.45.1")
+
+jsonnet = use_extension("//jsonnet:extensions.bzl", "jsonnet")
+use_repo(jsonnet, "rules_jsonnet_toolchain")
+register_toolchains("@rules_jsonnet_toolchain//:toolchain")
+
+rust_host = use_extension("@rules_rust//rust:extensions.bzl", "rust_host_tools")
+rust_host.host_tools(
+    version = "nightly/2024-05-02",
+)
+
+rust = use_extension("@rules_rust//rust:extensions.bzl", "rust")
+rust.toolchain(
+    edition = "2021",
+    # Nightly version is required to be able to depend on a binary dependency
+    # with Cargo.
+    # See https://doc.rust-lang.org/nightly/cargo/reference/unstable.html#artifact-dependencies.
+    versions = ["nightly/2024-05-01"],
+    sha256s = {
+        "2024-05-01/rustc-nightly-aarch64-apple-darwin.tar.xz": "3c3d4693b8e846c9c250bb14a97654657ca62a5eb20617a875c34462582daf83",
+        "2024-05-01/clippy-nightly-aarch64-apple-darwin.tar.xz": "379e22e343a7b1c2e39b030810ff633d800d0daae0f8fd6bf00181402c42be4e",
+        "2024-05-01/cargo-nightly-aarch64-apple-darwin.tar.xz": "899aec41e675146359d30a296db488f114cd280aef9dea566e178a8bb6f33774",
+        "2024-05-01/llvm-tools-nightly-aarch64-apple-darwin.tar.xz": "4b04ceaf724bea888fb1e5e6bd9a9a963196f585d4f73036e783a2c51d4e907e",
+        "2024-05-01/rust-std-nightly-aarch64-apple-darwin.tar.xz": "bf52ea3e1ac669455694079fb83b6bd0d446e759b9ab3502f75615d538e646a0",
+    },
+)
+
+use_repo(rust, "rust_toolchains")
+register_toolchains("@rust_toolchains//:all")
+
+crate = use_extension("@rules_rust//crate_universe:extension.bzl", "crate")
+crate.spec(
+    package = "jrsonnet",
+    version = "0.5.0-pre95",
+    # Binary artifacts can't be depended upon without specifically marking the
+    # artifact as `bin`.
+    artifact = "bin",
+)
+
+# Required for rules_rust to generate binary targets for the Jrsonnet crate.
+crate.annotation(
+    crate = "jrsonnet",
+    gen_binaries = ["jrsonnet"],
+)
+crate.from_specs()
+use_repo(crate, "crates")

--- a/docs/BUILD.bazel
+++ b/docs/BUILD.bazel
@@ -2,7 +2,7 @@ load("@aspect_bazel_lib//lib:docs.bzl", "stardoc_with_diff_test", "update_docs")
 
 stardoc_with_diff_test(
     name = "jsonnet",
-    bzl_library_target = "@rules_jsonnet//jsonnet:jsonnet",
+    bzl_library_target = "@rules_jsonnet//jsonnet:docs",
 )
 
 update_docs(

--- a/docs/jsonnet.md
+++ b/docs/jsonnet.md
@@ -1,6 +1,6 @@
 <!-- Generated with Stardoc: http://skydoc.bazel.build -->
 
-Jsonnet Rules
+# Jsonnet Rules
 
 These are build rules for working with [Jsonnet][jsonnet] files with Bazel.
 
@@ -16,7 +16,7 @@ instructions on [the releases page](https://github.com/bazelbuild/rules_jsonnet/
 ## jsonnet_library
 
 <pre>
-jsonnet_library(<a href="#jsonnet_library-name">name</a>, <a href="#jsonnet_library-deps">deps</a>, <a href="#jsonnet_library-srcs">srcs</a>, <a href="#jsonnet_library-data">data</a>, <a href="#jsonnet_library-imports">imports</a>, <a href="#jsonnet_library-jsonnet">jsonnet</a>)
+jsonnet_library(<a href="#jsonnet_library-name">name</a>, <a href="#jsonnet_library-deps">deps</a>, <a href="#jsonnet_library-srcs">srcs</a>, <a href="#jsonnet_library-data">data</a>, <a href="#jsonnet_library-imports">imports</a>)
 </pre>
 
 Creates a logical set of Jsonnet files.
@@ -60,7 +60,6 @@ Example:
 | <a id="jsonnet_library-srcs"></a>srcs |  List of `.jsonnet` files that comprises this Jsonnet library   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
 | <a id="jsonnet_library-data"></a>data |  -   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
 | <a id="jsonnet_library-imports"></a>imports |  List of import `-J` flags to be passed to the `jsonnet` compiler.   | List of strings | optional |  `[]`  |
-| <a id="jsonnet_library-jsonnet"></a>jsonnet |  A jsonnet binary   | <a href="https://bazel.build/concepts/labels">Label</a> | optional |  `"@rules_jsonnet//jsonnet:jsonnet_tool"`  |
 
 
 <a id="jsonnet_to_json"></a>
@@ -70,7 +69,7 @@ Example:
 <pre>
 jsonnet_to_json(<a href="#jsonnet_to_json-name">name</a>, <a href="#jsonnet_to_json-deps">deps</a>, <a href="#jsonnet_to_json-src">src</a>, <a href="#jsonnet_to_json-data">data</a>, <a href="#jsonnet_to_json-outs">outs</a>, <a href="#jsonnet_to_json-code_vars">code_vars</a>, <a href="#jsonnet_to_json-ext_code">ext_code</a>, <a href="#jsonnet_to_json-ext_code_envs">ext_code_envs</a>, <a href="#jsonnet_to_json-ext_code_file_vars">ext_code_file_vars</a>,
                 <a href="#jsonnet_to_json-ext_code_files">ext_code_files</a>, <a href="#jsonnet_to_json-ext_str_envs">ext_str_envs</a>, <a href="#jsonnet_to_json-ext_str_file_vars">ext_str_file_vars</a>, <a href="#jsonnet_to_json-ext_str_files">ext_str_files</a>, <a href="#jsonnet_to_json-ext_strs">ext_strs</a>, <a href="#jsonnet_to_json-extra_args">extra_args</a>,
-                <a href="#jsonnet_to_json-imports">imports</a>, <a href="#jsonnet_to_json-jsonnet">jsonnet</a>, <a href="#jsonnet_to_json-multiple_outputs">multiple_outputs</a>, <a href="#jsonnet_to_json-out_dir">out_dir</a>, <a href="#jsonnet_to_json-stamp_keys">stamp_keys</a>, <a href="#jsonnet_to_json-tla_code">tla_code</a>, <a href="#jsonnet_to_json-tla_code_envs">tla_code_envs</a>,
+                <a href="#jsonnet_to_json-imports">imports</a>, <a href="#jsonnet_to_json-multiple_outputs">multiple_outputs</a>, <a href="#jsonnet_to_json-out_dir">out_dir</a>, <a href="#jsonnet_to_json-stamp_keys">stamp_keys</a>, <a href="#jsonnet_to_json-tla_code">tla_code</a>, <a href="#jsonnet_to_json-tla_code_envs">tla_code_envs</a>,
                 <a href="#jsonnet_to_json-tla_code_files">tla_code_files</a>, <a href="#jsonnet_to_json-tla_str_envs">tla_str_envs</a>, <a href="#jsonnet_to_json-tla_str_files">tla_str_files</a>, <a href="#jsonnet_to_json-tla_strs">tla_strs</a>, <a href="#jsonnet_to_json-vars">vars</a>, <a href="#jsonnet_to_json-yaml_stream">yaml_stream</a>)
 </pre>
 
@@ -200,7 +199,6 @@ Example:
 | <a id="jsonnet_to_json-ext_strs"></a>ext_strs |  -   | <a href="https://bazel.build/rules/lib/dict">Dictionary: String -> String</a> | optional |  `{}`  |
 | <a id="jsonnet_to_json-extra_args"></a>extra_args |  Additional command line arguments for the Jsonnet interpreter.<br><br>For example, setting this argument to `["--string"]` causes the interpreter to manifest the output file(s) as plain text instead of JSON.   | List of strings | optional |  `[]`  |
 | <a id="jsonnet_to_json-imports"></a>imports |  List of import `-J` flags to be passed to the `jsonnet` compiler.   | List of strings | optional |  `[]`  |
-| <a id="jsonnet_to_json-jsonnet"></a>jsonnet |  A jsonnet binary   | <a href="https://bazel.build/concepts/labels">Label</a> | optional |  `"@rules_jsonnet//jsonnet:jsonnet_tool"`  |
 | <a id="jsonnet_to_json-multiple_outputs"></a>multiple_outputs |  Set to `True` to explicitly enable multiple file output via the `jsonnet -m` flag.<br><br>This is used for the case where multiple file output is used but only for generating a single output file. For example:<br><br><pre><code>local foo = import "foo.jsonnet";&#10;&#10;{&#10;    "foo.json": foo,&#10;}</code></pre><br><br>This attribute is incompatible with `out_dir`.   | Boolean | optional |  `False`  |
 | <a id="jsonnet_to_json-out_dir"></a>out_dir |  Name of the directory where output files are stored.<br><br>If the names of output files are not known up front, this option can be used to write all output files to a single directory artifact. Files in this directory cannot be referenced individually.<br><br>This attribute is incompatible with `outs` and `multiple_outputs`.   | String | optional |  `""`  |
 | <a id="jsonnet_to_json-stamp_keys"></a>stamp_keys |  -   | List of strings | optional |  `[]`  |
@@ -221,7 +219,7 @@ Example:
 <pre>
 jsonnet_to_json_test(<a href="#jsonnet_to_json_test-name">name</a>, <a href="#jsonnet_to_json_test-deps">deps</a>, <a href="#jsonnet_to_json_test-src">src</a>, <a href="#jsonnet_to_json_test-data">data</a>, <a href="#jsonnet_to_json_test-canonicalize_golden">canonicalize_golden</a>, <a href="#jsonnet_to_json_test-code_vars">code_vars</a>, <a href="#jsonnet_to_json_test-error">error</a>, <a href="#jsonnet_to_json_test-ext_code">ext_code</a>,
                      <a href="#jsonnet_to_json_test-ext_code_envs">ext_code_envs</a>, <a href="#jsonnet_to_json_test-ext_code_file_vars">ext_code_file_vars</a>, <a href="#jsonnet_to_json_test-ext_code_files">ext_code_files</a>, <a href="#jsonnet_to_json_test-ext_str_envs">ext_str_envs</a>,
-                     <a href="#jsonnet_to_json_test-ext_str_file_vars">ext_str_file_vars</a>, <a href="#jsonnet_to_json_test-ext_str_files">ext_str_files</a>, <a href="#jsonnet_to_json_test-ext_strs">ext_strs</a>, <a href="#jsonnet_to_json_test-extra_args">extra_args</a>, <a href="#jsonnet_to_json_test-golden">golden</a>, <a href="#jsonnet_to_json_test-imports">imports</a>, <a href="#jsonnet_to_json_test-jsonnet">jsonnet</a>,
+                     <a href="#jsonnet_to_json_test-ext_str_file_vars">ext_str_file_vars</a>, <a href="#jsonnet_to_json_test-ext_str_files">ext_str_files</a>, <a href="#jsonnet_to_json_test-ext_strs">ext_strs</a>, <a href="#jsonnet_to_json_test-extra_args">extra_args</a>, <a href="#jsonnet_to_json_test-golden">golden</a>, <a href="#jsonnet_to_json_test-imports">imports</a>,
                      <a href="#jsonnet_to_json_test-output_file_contents">output_file_contents</a>, <a href="#jsonnet_to_json_test-regex">regex</a>, <a href="#jsonnet_to_json_test-stamp_keys">stamp_keys</a>, <a href="#jsonnet_to_json_test-tla_code">tla_code</a>, <a href="#jsonnet_to_json_test-tla_code_envs">tla_code_envs</a>, <a href="#jsonnet_to_json_test-tla_code_files">tla_code_files</a>,
                      <a href="#jsonnet_to_json_test-tla_str_envs">tla_str_envs</a>, <a href="#jsonnet_to_json_test-tla_str_files">tla_str_files</a>, <a href="#jsonnet_to_json_test-tla_strs">tla_strs</a>, <a href="#jsonnet_to_json_test-vars">vars</a>, <a href="#jsonnet_to_json_test-yaml_stream">yaml_stream</a>)
 </pre>
@@ -348,7 +346,6 @@ Example:
 | <a id="jsonnet_to_json_test-extra_args"></a>extra_args |  Additional command line arguments for the Jsonnet interpreter.<br><br>For example, setting this argument to `["--string"]` causes the interpreter to manifest the output file(s) as plain text instead of JSON.   | List of strings | optional |  `[]`  |
 | <a id="jsonnet_to_json_test-golden"></a>golden |  The expected (combined stdout and stderr) output to compare to the output of running `jsonnet` on `src`.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional |  `None`  |
 | <a id="jsonnet_to_json_test-imports"></a>imports |  List of import `-J` flags to be passed to the `jsonnet` compiler.   | List of strings | optional |  `[]`  |
-| <a id="jsonnet_to_json_test-jsonnet"></a>jsonnet |  A jsonnet binary   | <a href="https://bazel.build/concepts/labels">Label</a> | optional |  `"@rules_jsonnet//jsonnet:jsonnet_tool"`  |
 | <a id="jsonnet_to_json_test-output_file_contents"></a>output_file_contents |  -   | Boolean | optional |  `True`  |
 | <a id="jsonnet_to_json_test-regex"></a>regex |  Set to 1 if `golden` contains a regex used to match the output of running `jsonnet` on `src`.   | Boolean | optional |  `False`  |
 | <a id="jsonnet_to_json_test-stamp_keys"></a>stamp_keys |  -   | List of strings | optional |  `[]`  |
@@ -362,29 +359,24 @@ Example:
 | <a id="jsonnet_to_json_test-yaml_stream"></a>yaml_stream |  -   | Boolean | optional |  `False`  |
 
 
-<a id="JsonnetLibraryInfo"></a>
+<a id="jsonnet_toolchain"></a>
 
-## JsonnetLibraryInfo
-
-<pre>
-JsonnetLibraryInfo()
-</pre>
-
-
-
-**FIELDS**
-
-
-
-<a id="jsonnet_repositories"></a>
-
-## jsonnet_repositories
+## jsonnet_toolchain
 
 <pre>
-jsonnet_repositories()
+jsonnet_toolchain(<a href="#jsonnet_toolchain-name">name</a>, <a href="#jsonnet_toolchain-compiler">compiler</a>, <a href="#jsonnet_toolchain-create_directory_flags">create_directory_flags</a>, <a href="#jsonnet_toolchain-manifest_file_support">manifest_file_support</a>)
 </pre>
 
-Adds the external dependencies needed for the Jsonnet rules.
+The Jsonnet compiler information.
 
+**ATTRIBUTES**
+
+
+| Name  | Description | Type | Mandatory | Default |
+| :------------- | :------------- | :------------- | :------------- | :------------- |
+| <a id="jsonnet_toolchain-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
+| <a id="jsonnet_toolchain-compiler"></a>compiler |  -   | <a href="https://bazel.build/concepts/labels">Label</a> | optional |  `None`  |
+| <a id="jsonnet_toolchain-create_directory_flags"></a>create_directory_flags |  The flags passed to the Jsonnet compiler when a directory must be created.   | List of strings | required |  |
+| <a id="jsonnet_toolchain-manifest_file_support"></a>manifest_file_support |  If the Jsonnet compiler supports writing the output filenames to a manifest file.   | Boolean | required |  |
 
 

--- a/examples/BUILD
+++ b/examples/BUILD
@@ -1,10 +1,10 @@
+load("@rules_jsonnet//jsonnet:jsonnet.bzl", "jsonnet_library", "jsonnet_to_json", "jsonnet_to_json_test")
+
 package(default_visibility = ["//visibility:public"])
 
 # This directory contains unit and regression tests that also serve as examples
 # for jsonnet rules.  The BUILD rules should not contain any jsonnet_to_json
 # rules as this is redundant with jsonnet_to_json_test rules.
-
-load("@rules_jsonnet//jsonnet:jsonnet.bzl", "jsonnet_library", "jsonnet_to_json", "jsonnet_to_json_test")
 
 jsonnet_library(
     name = "workflow",

--- a/examples/MODULE.bazel
+++ b/examples/MODULE.bazel
@@ -9,8 +9,24 @@ local_path_override(
     path = "..",
 )
 
+jsonnet = use_extension("@rules_jsonnet//jsonnet:extensions.bzl", "jsonnet")
+jsonnet.compiler(name = "go")
+
 bazel_dep(name = "other_module", version = "0.0.0")
 local_path_override(
     module_name = "other_module",
     path = "other_module",
+)
+
+bazel_dep(name = "other_toolchain_module", version = "0.0.0")
+local_path_override(
+    module_name = "other_toolchain_module",
+    path = "other_toolchain_module",
+)
+
+bazel_dep(name = "rules_rust", version = "0.45.1")
+
+rust_host = use_extension("@rules_rust//rust:extensions.bzl", "rust_host_tools")
+rust_host.host_tools(
+    version = "nightly/2024-05-02",
 )

--- a/examples/invalid.out
+++ b/examples/invalid.out
@@ -1,3 +1,1 @@
-^RUNTIME ERROR: Foo\.
-	.*invalid\.jsonnet:15:1-13	($|\$
-	During evaluation	)
+^RUNTIME ERROR: Foo.*invalid\.jsonnet:15:1-13*

--- a/examples/other_module/MODULE.bazel
+++ b/examples/other_module/MODULE.bazel
@@ -4,3 +4,6 @@ module(
 )
 
 bazel_dep(name = "rules_jsonnet", version = "0.0.0")
+
+jsonnet = use_extension("@rules_jsonnet//jsonnet:extensions.bzl", "jsonnet")
+jsonnet.compiler(name = "rust")

--- a/examples/other_toolchain_module/MODULE.bazel
+++ b/examples/other_toolchain_module/MODULE.bazel
@@ -1,0 +1,13 @@
+# This module 'other_toolchain_module' is here to test multiple modules
+# providing different toolchains and the logic in the toolchain conflict
+# resolution logic.
+
+module(
+    name = "other_toolchain_module",
+    version = "0.0.0",
+)
+
+bazel_dep(name = "rules_jsonnet", version = "0.0.0")
+
+jsonnet = use_extension("@rules_jsonnet//jsonnet:extensions.bzl", "jsonnet")
+jsonnet.compiler(name = "rust")

--- a/examples/out_dir.jsonnet
+++ b/examples/out_dir.jsonnet
@@ -1,5 +1,4 @@
 {
   'hello.txt': 'Hello, Bazel!',
   'goodbye.txt': 'Goodbye, Bazel!',
-  'nested/nested.txt': 'This file is in a nested directory.',
 }

--- a/jsonnet/BUILD
+++ b/jsonnet/BUILD
@@ -1,6 +1,7 @@
+load(":toolchain.bzl", "jsonnet_toolchain")
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 
-exports_files(["jsonnet.bzl"])
+exports_files(["docs.bzl", "jsonnet.bzl", "toolchain.bzl"])
 
 bzl_library(
     name = "bzl_srcs",
@@ -8,8 +9,12 @@ bzl_library(
 )
 
 bzl_library(
-    name = "jsonnet",
-    srcs = ["jsonnet.bzl"],
+    name = "docs",
+    srcs = [
+        "docs.bzl",
+        "jsonnet.bzl",
+        "toolchain.bzl",
+    ],
     visibility = ["//visibility:public"],
     deps = [
         ":bzl_srcs",
@@ -25,25 +30,46 @@ py_binary(
     visibility = ["//visibility:public"],
 )
 
-config_setting(
-    name = "port_cpp",
-    define_values = {
-        "jsonnet_port": "cpp",
-    },
+toolchain_type(name = "toolchain_type")
+
+jsonnet_toolchain(
+    name = "rust_jsonnet",
+    compiler = "@crates//:jrsonnet__jrsonnet",
+    create_directory_flags = ["-c"],
+    manifest_file_support = False,
 )
 
-config_setting(
-    name = "port_go",
-    define_values = {
-        "jsonnet_port": "go",
-    },
+jsonnet_toolchain(
+    name = "go_jsonnet",
+    compiler = "@google_jsonnet_go//cmd/jsonnet",
+    create_directory_flags = ["-c"],
+    manifest_file_support = True,
 )
 
-alias(
-    name = "jsonnet_tool",
-    actual = select({
-        "//jsonnet:port_cpp": "@jsonnet//cmd:jsonnet",
-        "//conditions:default": "@google_jsonnet_go//cmd/jsonnet",
-    }),
+jsonnet_toolchain(
+    name = "cpp_jsonnet",
+    compiler = "@jsonnet//cmd:jsonnet",
+    create_directory_flags = [],
+    manifest_file_support = True,
+)
+
+toolchain(
+    name = "rust_jsonnet_toolchain",
+    toolchain = ":rust_jsonnet",
+    toolchain_type = ":toolchain_type",
+    visibility = ["//visibility:public"],
+)
+
+toolchain(
+    name = "go_jsonnet_toolchain",
+    toolchain = ":go_jsonnet",
+    toolchain_type = ":toolchain_type",
+    visibility = ["//visibility:public"],
+)
+
+toolchain(
+    name = "cpp_jsonnet_toolchain",
+    toolchain = ":cpp_jsonnet",
+    toolchain_type = ":toolchain_type",
     visibility = ["//visibility:public"],
 )

--- a/jsonnet/docs.bzl
+++ b/jsonnet/docs.bzl
@@ -1,0 +1,25 @@
+"""\
+# Jsonnet Rules
+
+These are build rules for working with [Jsonnet][jsonnet] files with Bazel.
+
+[jsonnet]: https://jsonnet.org/
+
+## Setup
+
+To use the Jsonnet rules as part of your Bazel project, please follow the
+instructions on [the releases page](https://github.com/bazelbuild/rules_jsonnet/releases).
+"""
+
+load("//jsonnet:toolchain.bzl", _jsonnet_toolchain = "jsonnet_toolchain")
+load(
+    "//jsonnet:jsonnet.bzl",
+    _jsonnet_library = "jsonnet_library",
+    _jsonnet_to_json = "jsonnet_to_json",
+    _jsonnet_to_json_test = "jsonnet_to_json_test",
+)
+
+jsonnet_toolchain = _jsonnet_toolchain
+jsonnet_library = _jsonnet_library
+jsonnet_to_json = _jsonnet_to_json
+jsonnet_to_json_test = _jsonnet_to_json_test

--- a/jsonnet/extensions.bzl
+++ b/jsonnet/extensions.bzl
@@ -1,0 +1,68 @@
+def _get_jsonnet_compiler(module_ctx):
+    """_get_jsonnet_compiler resolves a Jsonnet compiler from the module graph."""
+
+    modules_with_compiler = [
+        module
+        for module in module_ctx.modules
+        if module.tags.compiler
+    ]
+
+    if not modules_with_compiler:
+        return "go"
+
+    for module in modules_with_compiler:
+        if len(module.tags.compiler) != 1:
+            fail(
+                "Only one compiler can be specified, got: %s" %
+                [compiler.name for compiler in module.tags.compiler],
+            )
+
+        if module.is_root:
+            return module.tags.compiler[0].name
+
+    compiler_name = modules_with_compiler[0].tags.compiler[0].name
+    for module in modules_with_compiler:
+        if module.tags.compiler[0].name != compiler_name:
+            fail(
+                "Different compilers specified by different modules, got: %s. " %
+                [compiler_name, module.tags.compiler[0].name] +
+                "Specify a compiler in the root module to resolve this.",
+            )
+
+    return compiler_name
+
+def _jsonnet_impl(module_ctx):
+    _jsonnet_toolchain_repo(
+        name = "rules_jsonnet_toolchain",
+        compiler = _get_jsonnet_compiler(module_ctx),
+    )
+
+jsonnet = module_extension(
+    implementation = _jsonnet_impl,
+    tag_classes = {
+        "compiler": tag_class(
+            attrs = {
+                "name": attr.string(),
+            },
+        ),
+    },
+)
+
+def _jsonnet_toolchain_repo_impl(ctx):
+    ctx.file(
+        "BUILD.bazel",
+        content = """
+alias(
+    name = "toolchain",
+    actual = "@io_bazel_rules_jsonnet//jsonnet:%s_jsonnet_toolchain",
+)
+""" % ctx.attr.compiler,
+        executable = False,
+    )
+
+_jsonnet_toolchain_repo = repository_rule(
+    implementation = _jsonnet_toolchain_repo_impl,
+    attrs = {
+        "compiler": attr.string(),
+    },
+)

--- a/jsonnet/toolchain.bzl
+++ b/jsonnet/toolchain.bzl
@@ -1,0 +1,46 @@
+JsonnetToolchainInfo = provider(
+    doc = "Jsonnet toolchain provider",
+    fields = {
+        "compiler": "The file to the Jsonnet compiler",
+        "create_directory_flags": "The flags to pass when creating a directory.",
+        "manifest_file_support": (
+            "If the Jsonnet compiler supports writing the output filenames to a " +
+            "manifest file."
+        ),
+    },
+)
+
+def _jsonnet_toolchain_impl(ctx):
+    toolchain_info = platform_common.ToolchainInfo(
+        jsonnetinfo = JsonnetToolchainInfo(
+            compiler = ctx.executable.compiler,
+            create_directory_flags = ctx.attr.create_directory_flags,
+            manifest_file_support = ctx.attr.manifest_file_support,
+        ),
+    )
+    return [toolchain_info]
+
+jsonnet_toolchain = rule(
+    implementation = _jsonnet_toolchain_impl,
+    doc = "The Jsonnet compiler information.",
+    attrs = {
+        "compiler": attr.label(
+            executable = True,
+            cfg = "exec",
+        ),
+        "create_directory_flags": attr.string_list(
+            mandatory = True,
+            doc = (
+                "The flags passed to the Jsonnet compiler when a directory " +
+                "must be created."
+            ),
+        ),
+        "manifest_file_support": attr.bool(
+            mandatory = True,
+            doc = (
+                "If the Jsonnet compiler supports writing the output filenames " +
+                "to a manifest file."
+            ),
+        ),
+    },
+)


### PR DESCRIPTION
This adds the Bazel toolchain support to change the effective Jsonnet compiler. Go-Jsonnet, Jsonnet (cpp) and Jrsonnet (Rust) are implemented.

There are some incompatibilities:

- Jsonnet (cpp) does not support the -c flag to create nested output directories.

- Jrsonnet (Rust) does not support manifest files containing the files that were generated by the Jsonnet program. It's currently only able to write those outputs to stdout.

- Jrsonnet text output (e.g. errors) is different compared to the cpp and Go implementations.

Due to these incompatibilities there are two addditional attributes on the toolchain: the flags to pass during directory creation and if manifest files are supported.

When adding rules_jsonnet as a bzlmod module, a user can now select the preferred compiler by using:

```
jsonnet = use_extension("@rules_jsonnet//jsonnet:extensions.bzl", "jsonnet")
jsonnet.compiler(name = "rust")
```

Currently there are three options: `cpp`, `go` and `rust`.

Additionally, this fixes CI:

The current .bazelci expects a variable ${{ jsonnet_port }} to be defined. However, that isn't the case with the current setup. The current behaviour is an empty ${{ jsonnet_port }} which causes the implementation to fall back to the default (Go), effectively disabling the cpp tests.

The CI runs:

```
bazel test //... --extra_toolchains=@rules_jsonnet//jsonnet:go_jsonnet_toolchain
bazel test //... --extra_toolchains=@rules_jsonnet//jsonnet:rust_jsonnet_toolchain
bazel test //... --extra_toolchains=@rules_jsonnet//jsonnet:cpp_jsonnet_toolchain
```

Lastly, fix docs:

The current docs setup only supports a single source file for docs generation (jsonnet.bzl). Now that `toolchains.bzl` is also a file that must be included in the docs generation, we use a helper file `docs.bzl` to aggregate what needs to be documented.

Note: 

To use the Rust Jsonnet compiler a `Nightly` Rust version for the host tools is
required because `-Z bindeps` is needed to compile the Jrsonnet binary.

Add the following snippet to the `Module.bazel` file:

```Starlark
bazel_dep(name = "rules_rust", version = "0.45.1")

rust_host = use_extension("@rules_rust//rust:extensions.bzl", "rust_host_tools")
rust_host.host_tools(
    version = "nightly/2024-05-02",
)
```
Fixes #150 

