### PR TITLE
Upgrade jsonnet to 0.21.0

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -4,8 +4,8 @@ module(
 )
 
 bazel_dep(name = "bazel_skylib", version = "1.7.1")
-bazel_dep(name = "jsonnet", version = "0.20.0")
-bazel_dep(name = "jsonnet_go", version = "0.20.0")
+bazel_dep(name = "jsonnet", version = "0.21.0")
+bazel_dep(name = "jsonnet_go", version = "0.21.0")
 bazel_dep(name = "rules_python", version = "1.2.0")
 bazel_dep(name = "rules_rust", version = "0.54.1")
 


### PR DESCRIPTION
Both C++ and Go versions has released 0.21.0 a month ago, so maybe we can upgrade rules_jsonnet too?