### PR TITLE
Add support for extvars in `jsonnet_library`

### DIFF
--- a/examples/BUILD
+++ b/examples/BUILD
@@ -336,3 +336,46 @@ jsonnet_to_json(
         "multiple_outs_nested_asymmetric/file.json",
     ],
 )
+
+jsonnet_library(
+    name = "extvar-lib",
+    srcs = [
+        "extvar.libsonnet",
+    ],
+    ext_strs = {
+        "non_stamp": "non_stamp",
+        "mydefine": "$(mydefine)",
+        "k8s": "{STABLE_K8S_CLUSTER}",
+    },
+    ext_str_files = {
+        ":test_str_files": "str_files"
+    },
+    ext_code_envs = ["MYJSONNET"],
+    ext_str_envs = ["MYTEST"],
+    ext_code_libraries = {
+        ":code_library_lib": "ext_lib"
+    },
+)
+
+jsonnet_to_json_test(
+    name = "extvar-lib-test",
+    src = "extvar-library.jsonnet",
+    golden = "extvar-library.json",
+    deps = [
+        ":extvar-lib",
+    ],
+)
+
+jsonnet_to_json(
+    name = "extvar-lib-json",
+    outs = ["ext-lib.json"],
+    src = "extvar-library.jsonnet",
+    deps = [
+        ":extvar-lib",
+    ],
+    ext_strs = {
+        "non_stamp": "non_stamp",
+    },
+    ext_code_envs = ["MYJSONNET"],
+    ext_str_envs = ["MYTEST"],
+)

--- a/examples/BUILD
+++ b/examples/BUILD
@@ -120,14 +120,14 @@ jsonnet_to_json_test(
 jsonnet_library(
     name = "code_library_lib",
     srcs = ["code_library.libsonnet"],
-    deps = [":workflow"]
+    deps = [":workflow"],
 )
 
 jsonnet_to_json_test(
     name = "extvar_code_library_test",
     size = "small",
     src = "extvar_code_library.jsonnet",
-    ext_code_libraries = { ":code_library_lib": "codefile" },
+    ext_code_libraries = {":code_library_lib": "codefile"},
     golden = "extvar_files_library_golden.json",
 )
 
@@ -135,8 +135,8 @@ jsonnet_to_json_test(
     name = "tla_code_library_test",
     size = "small",
     src = "tla_code_library.jsonnet",
-    tla_code_libraries = { ":code_library_lib": "tla_code" },
     golden = "tla_code_library_golden.json",
+    tla_code_libraries = {":code_library_lib": "tla_code"},
 )
 
 jsonnet_to_json_test(
@@ -342,18 +342,18 @@ jsonnet_library(
     srcs = [
         "extvar.libsonnet",
     ],
+    ext_code_envs = ["MYJSONNET"],
+    ext_code_libraries = {
+        ":code_library_lib": "ext_lib",
+    },
+    ext_str_envs = ["MYTEST"],
+    ext_str_files = {
+        ":test_str_files": "str_files",
+    },
     ext_strs = {
         "non_stamp": "non_stamp",
         "mydefine": "$(mydefine)",
         "k8s": "{STABLE_K8S_CLUSTER}",
-    },
-    ext_str_files = {
-        ":test_str_files": "str_files"
-    },
-    ext_code_envs = ["MYJSONNET"],
-    ext_str_envs = ["MYTEST"],
-    ext_code_libraries = {
-        ":code_library_lib": "ext_lib"
     },
 )
 
@@ -368,14 +368,14 @@ jsonnet_to_json_test(
 
 jsonnet_to_json(
     name = "extvar-lib-json",
-    outs = ["ext-lib.json"],
     src = "extvar-library.jsonnet",
-    deps = [
-        ":extvar-lib",
-    ],
+    outs = ["ext-lib.json"],
+    ext_code_envs = ["MYJSONNET"],
+    ext_str_envs = ["MYTEST"],
     ext_strs = {
         "non_stamp": "non_stamp",
     },
-    ext_code_envs = ["MYJSONNET"],
-    ext_str_envs = ["MYTEST"],
+    deps = [
+        ":extvar-lib",
+    ],
 )

--- a/examples/extvar-library.json
+++ b/examples/extvar-library.json
@@ -1,0 +1,13 @@
+{
+   "code_env": {
+      "code": "some code"
+   },
+   "library": {
+      "workflow": { }
+   },
+   "k8s": "{STABLE_K8S_CLUSTER}",
+   "mydefine": "",
+   "non_stamp": "non_stamp",
+   "str_env": "test",
+   "str_files": "this is great\n"
+}

--- a/examples/extvar-library.jsonnet
+++ b/examples/extvar-library.jsonnet
@@ -1,0 +1,1 @@
+import 'extvar.libsonnet'

--- a/examples/extvar.libsonnet
+++ b/examples/extvar.libsonnet
@@ -1,0 +1,9 @@
+{
+  non_stamp: std.extVar('non_stamp'),
+  mydefine: std.extVar('mydefine'),
+  k8s: std.extVar('k8s'),
+  str_files: std.extVar('str_files'),
+  code_env: std.extVar('MYJSONNET'),
+  str_env: std.extVar('MYTEST'),
+  library: std.extVar('ext_lib'),
+}

--- a/jsonnet/jsonnet.bzl
+++ b/jsonnet/jsonnet.bzl
@@ -306,7 +306,7 @@ def _jsonnet_library_impl(ctx):
             imports = imports,
             short_imports = short_imports,
             transitive_jsonnet_files = sources,
-            transitive_extvars = transitive_extvars,
+            transitive_extvars = depinfo.transitive_extvars,
         ),
     ]
 


### PR DESCRIPTION
# Intent

Implement the suggestion from #89 to resolve a problem of needing to reference generated files from deep in a `jsonnet_library` dependency graph.

A concrete use case that this could help is having a `jsonnet_library` that loads an external file, such as https://github.com/jsonnet-libs/k8s-libsonnet . To use this library internally you need to have the jsonnet code similar to:


```starlark
jsonnet_library(
  name = "k8s-libsonnet",
  srcs = ["main.libsonnet"],
  deps = [
    "@com_github_jsonnet_libs_k8s_libjsonnet//:files",
  ],
)
```

```jsonnet
// main.libsonnet
import 'external/com_github_jsonnet_libs_k8s_libjsonnet/main.jsonnet'
```

The above being for a WORKSPACE file, the will change depending how it is setup as a Bazel Mod and the Bazel version used.

With this change, this could be changed to:

```starlark
jsonnet_library(
  name = "k8s-libsonnet",
  srcs = ["main.libsonnet"],
  ext_code_files = {
    "@com_github_jsonnet_libs_k8s_libjsonnet//:files": "k8s_libsonnet_main"
  },
)
```

```jsonnet
// main.libsonnet
std.extVar('k8s_libsonnet_main')
```


Another use case, as the original author of #89 described, use of this is including generated files with `std.extVar` instead of using `importstr`.

# Design

The design of this implementation revolves around a `extvar_dict` which gathers the required information about `extvar`'s from the deps tree of `jsonnet_library` and make them compatible with `jsonnet_to_json{,_test}`.

## Implementation Notes

To do this, the implementation adds a new field to `JsonnetLibraryInfo`, `transistive_extvars`, which is a dictionary that is keyed on `extvar` name and contains a dict that contains:

```
{
  "type": str, // code, string, code_file, string_file, code_env, string_env, code_library
  "value": File, // File to use
  "sources": List[str] // stringified labels for user friendly error reports
}
```

It also added three new functions to help handle `extvar`s from across `jsonnet_library` and how they propagate through `deps` to the final `jsonnet_to_json{,_test}` targets:

 1. `_make_extvar_dict` whose goal is to convert the `ctx.attr`'s into a uniform dict
 1. `_merge_extvars` whose goal is to combine multiple `extvar_dict` and ensure that duplicates are handled correctly
 1. `_extvar_to_arguments` whose goal is to convert back from the dict to string arguments

This has the behaviour of ensuring that the same `extvar` cannot be defined multiple times with different values. It does allow the same `extvar`s with the same value to be defined in multiple places to ensure having a common dependency across a dependency tree works. However, it does allow two different targets to define the same `extvar` in two places to keep in sync.