### PR TITLE
Ensure that `data` from code_libraries are included

### DIFF
--- a/examples/BUILD
+++ b/examples/BUILD
@@ -120,15 +120,15 @@ jsonnet_to_json_test(
 jsonnet_library(
     name = "code_library_lib",
     srcs = ["code_library.libsonnet"],
+    data = [":test_str_files"],
     deps = [":workflow"],
-    data = [":test_str_files"]
 )
 
 jsonnet_to_json_test(
     name = "extvar_code_library_test",
     size = "small",
     src = "extvar_code_library.jsonnet",
-    ext_code_libraries = { ":code_library_lib": "codefile" },
+    ext_code_libraries = {":code_library_lib": "codefile"},
     golden = "extvar_files_library_golden.json",
 )
 
@@ -136,8 +136,8 @@ jsonnet_to_json_test(
     name = "tla_code_library_test",
     size = "small",
     src = "tla_code_library.jsonnet",
-    tla_code_libraries = { ":code_library_lib": "tla_code" },
     golden = "tla_code_library_golden.json",
+    tla_code_libraries = {":code_library_lib": "tla_code"},
 )
 
 jsonnet_to_json_test(

--- a/examples/BUILD
+++ b/examples/BUILD
@@ -120,7 +120,8 @@ jsonnet_to_json_test(
 jsonnet_library(
     name = "code_library_lib",
     srcs = ["code_library.libsonnet"],
-    deps = [":workflow"]
+    deps = [":workflow"],
+    data = [":test_str_files"]
 )
 
 jsonnet_to_json_test(

--- a/examples/extvar_code_library.jsonnet
+++ b/examples/extvar_code_library.jsonnet
@@ -1,6 +1,8 @@
 local codefile = std.extVar('codefile');
+local data = importstr 'file.txt';
 
 {
   job: codefile.workflow.Job,
   shJob: codefile.workflow.ShJob,
+  data: data,
 }

--- a/examples/extvar_files_library_golden.json
+++ b/examples/extvar_files_library_golden.json
@@ -1,16 +1,17 @@
 {
-   "job": {
-      "deps": [ ],
-      "inputs": [ ],
-      "outputs": [ ],
-      "type": "base"
-   },
-   "shJob": {
-      "command": "",
-      "deps": [ ],
-      "inputs": [ ],
-      "outputs": [ ],
-      "type": "sh",
-      "vars": { }
-   }
+  "job": {
+    "deps": [],
+    "inputs": [],
+    "outputs": [],
+    "type": "base"
+  },
+  "shJob": {
+    "command": "",
+    "deps": [],
+    "inputs": [],
+    "outputs": [],
+    "type": "sh",
+    "vars": {}
+  },
+  "data": "this is great\n"
 }

--- a/jsonnet/jsonnet.bzl
+++ b/jsonnet/jsonnet.bzl
@@ -91,7 +91,7 @@ def _setup_deps(deps, tla_code_libraries = {}, ext_code_libraries = {}):
 def _jsonnet_library_impl(ctx):
     """Implementation of the jsonnet_library rule."""
     depinfo = _setup_deps(ctx.attr.deps)
-    sources = depset(ctx.files.srcs + ctx.files.data, transitive = [depinfo.transitive_sources])
+    sources = depset(ctx.files.srcs, transitive = [depinfo.transitive_sources])
     imports = depset(
         _get_import_paths(ctx.label, ctx.files.srcs, ctx.attr.imports, False),
         transitive = [depinfo.imports],
@@ -297,9 +297,15 @@ def _jsonnet_to_json_impl(ctx):
         outputs.append(compiled_json)
         command += [ctx.file.src.path, "-o", compiled_json.path]
 
-    transitive_data = depset(transitive = [dep.data_runfiles.files for dep in ctx.attr.deps] +
-                                          [l.files for l in jsonnet_tla_code_files.keys()] +
-                                          [l.files for l in jsonnet_tla_str_files.keys()])
+    transitive_data = depset(
+        transitive =
+            [dep.data_runfiles.files for dep in ctx.attr.deps] +
+            [l.files for l in jsonnet_tla_code_files.keys()] +
+            [l.files for l in jsonnet_tla_str_files.keys()] +
+            [l[DefaultInfo].data_runfiles.files for l in jsonnet_tla_code_libraries.keys()] +
+            [l[DefaultInfo].data_runfiles.files for l in jsonnet_ext_code_libraries.keys()],
+    )
+
     # NB(sparkprime): (1) transitive_data is never used, since runfiles is only
     # used when .files is pulled from it.  (2) This makes sense - jsonnet does
     # not need transitive dependencies to be passed on the commandline. It
@@ -502,7 +508,9 @@ def _jsonnet_to_json_test_impl(ctx):
     transitive_data = depset(
         transitive = [dep.data_runfiles.files for dep in ctx.attr.deps] +
                      [l.files for l in jsonnet_tla_code_files.keys()] +
-                     [l.files for l in jsonnet_tla_str_files.keys()],
+                     [l.files for l in jsonnet_tla_str_files.keys()] +
+                     [l[DefaultInfo].data_runfiles.files for l in jsonnet_tla_code_libraries.keys()] +
+                     [l[DefaultInfo].data_runfiles.files for l in jsonnet_ext_code_libraries.keys()],
     )
 
     test_inputs = (

--- a/jsonnet/jsonnet.bzl
+++ b/jsonnet/jsonnet.bzl
@@ -91,7 +91,7 @@ def _setup_deps(deps, tla_code_libraries = {}, ext_code_libraries = {}):
 def _jsonnet_library_impl(ctx):
     """Implementation of the jsonnet_library rule."""
     depinfo = _setup_deps(ctx.attr.deps)
-    sources = depset(ctx.files.srcs, transitive = [depinfo.transitive_sources])
+    sources = depset(ctx.files.srcs + ctx.files.data, transitive = [depinfo.transitive_sources])
     imports = depset(
         _get_import_paths(ctx.label, ctx.files.srcs, ctx.attr.imports, False),
         transitive = [depinfo.imports],


### PR DESCRIPTION
## Issue

When a `jsonnet_library` defined a `data` dependency and the `jsonnet_library` was included in a `{tla,ext}_code_libraries` (See updated `//:extvar_code_library_test`) the `data` was not being included which results in error like:

```
==================== Test output for //:extvar_code_library_test:
FAIL (exit code): extvar_code_library_test
Expected: 0
Actual: 1
Output: RUNTIME ERROR: couldn't open import "file.txt": no match locally or in the Jsonnet library path
s
        extvar_code_library.jsonnet:2:14-34     thunk <data> from <$>
        extvar_code_library.jsonnet:7:9-13      object <anonymous>
        Field "data"
        During manifestation

```

Digging into the sandbox, the `data` file (`files.txt` in the example `//:extvar_code_library_test`) looks like:

```
> ls /private/var/tmp/_bazel/e78a12433a29cf2af3c4357fe05a3925/execroot/_main/bazel-out/darwin_arm64
-fastbuild/bin/extvar_code_library_test.runfiles/_main/
code_library.libsonnet           extvar_code_library.jsonnet      workflow.libsonnet
extvar_code_library_test         extvar_files_library_golden.json
```

## Resolution

Adding the missing addition of the `data_runfiles` to the `transitive_data` in `jsonnet_to_json{,_test}`.

Updated the example to make use of this as well.