### PR TITLE
chore(deps): Update Jsonnet (C++ and Go) to 0.22.0

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -4,8 +4,8 @@ module(
 )
 
 bazel_dep(name = "bazel_skylib", version = "1.8.1")
-bazel_dep(name = "jsonnet", version = "0.21.0")
-bazel_dep(name = "jsonnet_go", version = "0.21.0")
+bazel_dep(name = "jsonnet", version = "0.22.0")
+bazel_dep(name = "jsonnet_go", version = "0.22.0")
 bazel_dep(name = "rules_python", version = "1.7.0")
 bazel_dep(name = "rules_rust", version = "0.68.1")
 


### PR DESCRIPTION
I published C++ and Go Jsonnet v0.22.0 today, and the Bazel modules for them are in the BCR:
- https://registry.bazel.build/modules/jsonnet/0.22.0
- https://registry.bazel.build/modules/jsonnet_go/0.22.0