### PR TITLE
Fix build by bumping deps

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -3,11 +3,11 @@ module(
     version = "0.7.2",
 )
 
-bazel_dep(name = "bazel_skylib", version = "1.8.1")
-bazel_dep(name = "jsonnet", version = "0.21.0")
-bazel_dep(name = "jsonnet_go", version = "0.21.0")
+bazel_dep(name = "bazel_skylib", version = "1.8.2")
+bazel_dep(name = "jsonnet", version = "0.22.0")
+bazel_dep(name = "jsonnet_go", version = "0.22.0")
 bazel_dep(name = "rules_python", version = "1.7.0")
-bazel_dep(name = "rules_rust", version = "0.68.1")
+bazel_dep(name = "rules_rust", version = "0.69.0")
 
 jsonnet = use_extension("//jsonnet:extensions.bzl", "jsonnet")
 use_repo(jsonnet, "rules_jsonnet_toolchain")


### PR DESCRIPTION
Bump jsonnet and jsonnet_go to fix the transitive error fo CCInfo being used by old rules_go. While I'm here bump skylib and rules_rust too.