### PR TITLE
fix: Bazel 9 compatibility (bump to 0.22.0) and export toolchain_type

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -4,8 +4,8 @@ module(
 )
 
 bazel_dep(name = "bazel_skylib", version = "1.8.1")
-bazel_dep(name = "jsonnet", version = "0.21.0")
-bazel_dep(name = "jsonnet_go", version = "0.21.0")
+bazel_dep(name = "jsonnet", version = "0.22.0")
+bazel_dep(name = "jsonnet_go", version = "0.22.0")
 bazel_dep(name = "rules_python", version = "1.7.0")
 bazel_dep(name = "rules_rust", version = "0.68.1")
 

--- a/jsonnet/BUILD
+++ b/jsonnet/BUILD
@@ -35,7 +35,10 @@ py_binary(
     visibility = ["//visibility:public"],
 )
 
-toolchain_type(name = "toolchain_type")
+toolchain_type(
+    name = "toolchain_type",
+    visibility = ["//visibility:public"],
+)
 
 jsonnet_toolchain(
     name = "rust_jsonnet",


### PR DESCRIPTION
Fixes #278.

## Bazel 9 compatibility (dep bump)

On Bazel 9 the source-built Jsonnet compilers fail to configure:

- The `jsonnet` 0.21.0 C++ sources' `BUILD` files (`@jsonnet//core`, `@jsonnet//cmd`) use bare `cc_library` / `cc_binary` / `cc_test`, which Bazel 9 removed and no longer auto-provides:
  > `This rule has been removed from Bazel. Please add a load() statement for it.`
- `jsonnet_go` 0.21.0 pins `rules_go` 0.53.0, whose `go/private/rules/cgo.bzl` references the removed `CcInfo` symbol, so `@go_toolchains//:all` fails to load during toolchain resolution for **any** target (even when the `cpp` compiler is selected, because `jsonnet_go` is an unconditional dep).

Bumping `jsonnet` and `jsonnet_go` to `0.22.0` fixes both: the v0.22.0 C++ `BUILD` files already `load("@rules_cc//cc:...", ...)`, and `jsonnet_go` 0.22.0 pulls `rules_go` 0.59.0, `gazelle` 0.47.0, and `rules_cc` — all Bazel-9 clean.

This is the same bump proposed in #272, #273, and #274, and validated green in #275 — thanks to those authors. This PR folds it together with the toolchain-type change below into one self-contained fix; happy to rebase and drop the bump hunk if one of those merges first.

## Expose `//jsonnet:toolchain_type`

`toolchain_type` had no `visibility`, so it defaulted to private. A downstream module that wants to register its own Jsonnet toolchain (e.g. a prebuilt compiler binary, to avoid building the compiler from source) cannot reference `@rules_jsonnet//jsonnet:toolchain_type` without patching this repo. Making it public is consistent with the `*_jsonnet_toolchain` targets, which are already public.

## Verification

On Bazel 9.1.0, `examples/` builds and tests pass with both compilers, with **no** `--incompatible_autoload_externally`:

```
# cpp
bazel test //... --extra_toolchains=@rules_jsonnet//jsonnet:cpp_jsonnet_toolchain
#   -> 25 tests pass

# go (examples default compiler)
bazel test //...
#   -> 25 tests pass
```
